### PR TITLE
PEDS-871 new request states

### DIFF
--- a/amanuensis/config-default.yaml
+++ b/amanuensis/config-default.yaml
@@ -95,7 +95,6 @@ OAUTH2:
   redirect_uri: 'https://{{HOSTNAME}}/amanuensis/oauth2/authorize'
 
 USER_API: 'http://fence-service/'
-AUDIENCE:
 # option to force authutils to prioritize USER_API setting over the issuer from
 # token when redirecting, used during local docker compose setup when the
 # services are on different containers but the hostname is still localhost
@@ -230,6 +229,19 @@ CONSORTIUM_STATUS:
       - "REJECTED"
       - "APPROVED"
       - "DATA_DELIVERED"
+      - "DRAFT"
+      - "SUBMITTED"
+      - "REVIEW"
+      - "REVISION"
+      - "APPROVED_WITH_FEEDBACK"
+      - "REQUEST_CRITERIA_FINALIZED"
+      - "APPROVED"
+      - "REJECTED"
+      - "WITHDRAWAL"
+      - "AGREEMENTS_NEGOTIATION"
+      - "AGREEMENTS_EXECUTED"
+      - "DATA_AVAILABLE"
+      - "DATA_DOWNLOADED"
     FINAL:
       - "REJECTED"
       - "DATA_DELIVERED"
@@ -242,6 +254,19 @@ CONSORTIUM_STATUS:
       - "REJECTED"
       - "APPROVED"
       - "DATA_DELIVERED"
+      - "DRAFT"
+      - "SUBMITTED"
+      - "REVIEW"
+      - "REVISION"
+      - "APPROVED_WITH_FEEDBACK"
+      - "REQUEST_CRITERIA_FINALIZED"
+      - "APPROVED"
+      - "REJECTED"
+      - "WITHDRAWAL"
+      - "AGREEMENTS_NEGOTIATION"
+      - "AGREEMENTS_EXECUTED"
+      - "DATA_AVAILABLE"
+      - "DATA_DOWNLOADED"
     FINAL:
       - "REJECTED"
       - "DATA_DELIVERED"

--- a/migrations/versions/fa0c3fdf48ea_add_request_states.py
+++ b/migrations/versions/fa0c3fdf48ea_add_request_states.py
@@ -22,8 +22,6 @@ logger = logging.getLogger("amanuensis.alembic")
 
 def upgrade() -> None:
 
-    conn = op.get_bind()
-    session = Session(bind=conn)
     states = []
 
     states.append(State(name="Draft", code="DRAFT"))
@@ -55,10 +53,29 @@ def upgrade() -> None:
 
     states.append(State(name="Published", code="PUBLISHED"))
 
+    conn = op.get_bind()
+    session = Session(bind=conn)
     session.add_all(states)
     session.commit()
 
 
 def downgrade() -> None:
-    pass
 
+    state_codes = [
+        "DRAFT",
+        "SUBMITTED",
+        "REVISION",
+        "APPROVED_WITH_FEEDBACK",
+        "REQUEST_CRITERIA_FINALIZED",
+        "WITHDRAWAL",
+        "AGREEMENTS_NEGOTIATION",
+        "AGREEMENTS_EXECUTED",
+        "DATA_AVAILABLE",
+        "DATA_DOWNLOADED",
+        "PUBLISHED",
+    ]
+    conn = op.get_bind()
+    session = Session(bind=conn)
+    for code in state_codes:
+        session.query(State).filter(State.code == code).delete()
+    session.commit()

--- a/migrations/versions/fa0c3fdf48ea_add_request_states.py
+++ b/migrations/versions/fa0c3fdf48ea_add_request_states.py
@@ -1,0 +1,64 @@
+"""Add request states
+
+Revision ID: fa0c3fdf48ea
+Revises: f7ef7b53a36e
+Create Date: 2022-12-12 19:23:41.792566
+
+"""
+import logging
+
+from alembic import op
+from sqlalchemy.orm import Session
+from userportaldatamodel.models import State
+
+# revision identifiers, used by Alembic.
+revision = "fa0c3fdf48ea"
+down_revision = "f7ef7b53a36e"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("amanuensis.alembic")
+
+
+def upgrade() -> None:
+
+    conn = op.get_bind()
+    session = Session(bind=conn)
+    states = []
+
+    states.append(State(name="Draft", code="DRAFT"))
+
+    states.append(State(name="Submitted", code="SUBMITTED"))
+
+    states.append(State(name="Revision", code="REVISION"))
+
+    states.append(State(name="Approved with Feedback", code="APPROVED_WITH_FEEDBACK"))
+
+    states.append(
+        State(name="Request Criteria Finalized", code="REQUEST_CRITERIA_FINALIZED")
+    )
+
+    states.append(State(name="Withdrawal", code="WITHDRAWAL"))
+
+    states.append(
+        State(
+            name="Agreements Negotiation",
+            code="AGREEMENTS_NEGOTIATION",
+        )
+    )
+
+    states.append(State(name="Agreements Executed", code="AGREEMENTS_EXECUTED"))
+
+    states.append(State(name="Data Available", code="DATA_AVAILABLE"))
+
+    states.append(State(name="Data Downloaded", code="DATA_DOWNLOADED"))
+
+    states.append(State(name="Published", code="PUBLISHED"))
+
+    session.add_all(states)
+    session.commit()
+
+
+def downgrade() -> None:
+    pass
+


### PR DESCRIPTION
Alembic migration adds the following states to database:

**Draft**: The user started the form but saves it to complete another day 

**Submitted**: the user sends the completed form to a PM (email or through the system)

**Review**: In the hand of the EC

**Revision**: back to the requestor, needs to respond to the EC questions or concerns. loop to review

**Approved with Feedback**: It is approved but it needs some changes with for example the filter-set before being approved

**Request Criteria Finalized**: Update the filterset or apply the feedback the EC gave

**Approved**: the request is approved

**Rejected**: the request is rejected

**Withdrawal**: The request has been withdrawn

**Agreements Negotiation**: Creating the agreements after the request is approved

**Agreements Executed**: The agreements is in place

**Data Available**: The data is ready to be submitted

**Data Downloaded**: When a user actually download the data

**Published**: Remove access to the data