### PR TITLE
PEDS-1096

### DIFF
--- a/amanuensis/resources/admin/admin_associated_user.py
+++ b/amanuensis/resources/admin/admin_associated_user.py
@@ -7,7 +7,7 @@ from amanuensis.config import config
 from amanuensis.resources import fence
 from amanuensis.resources import userdatamodel as udm
 from amanuensis.schema import AssociatedUserSchema
-from amanuensis.errors import UserError
+from amanuensis.errors import UserError, NotFound
 from amanuensis.models import AssociatedUserRoles
 
 logger = get_logger(__name__)
@@ -84,7 +84,10 @@ def add_associated_users(users, role=None):
             if not role:
                 role_id = session.query(AssociatedUserRoles.id).filter(AssociatedUserRoles.code == "METADATA_ACCESS").first()[0]
             else:
-                role_id = session.query(AssociatedUserRoles.id).filter(AssociatedUserRoles.code == role).first()[0]
+                try:
+                    role_id = session.query(AssociatedUserRoles.id).filter(AssociatedUserRoles.code == role).first()[0]
+                except TypeError:
+                    raise NotFound("input role is not a valid option")
             # Check if the user exists in amanuensis, if it does check it is in sync with fence and update if needed, if it doesn't add it using the fence info
             if not associated_user_by_email and not associated_user_by_id:
                 # Create the user in amanuensis

--- a/migrations/versions/40b00996555e_update_project_has_associated_user.py
+++ b/migrations/versions/40b00996555e_update_project_has_associated_user.py
@@ -30,7 +30,7 @@ def upgrade() -> None:
     logger.warn("userporataldatamodel must be at version 1.6.0 or greater")
     op.add_column("project_has_associated_user", sa.Column('role_id', sa.Integer, sa.ForeignKey('associated_user_roles.id')))
 
-    op.execute(f"UPDATE project_has_associated_user SET role_id = CASE WHEN role = 'DATA_ACCESS' THEN {roles_dict['DATA_ACCESS']} WHEN role = 'METADATA_ACCESS' THEN {roles_dict['METADATA_ACCESS']} ELSE NULL END")
+    op.execute(f"UPDATE project_has_associated_user SET role_id = CASE WHEN role = 'DATA_ACCESS' THEN {roles_dict['DATA_ACCESS']} WHEN role = 'METADATA_ACCESS' THEN {roles_dict['METADATA_ACCESS']} ELSE {roles_dict['METADATA_ACCESS']} END")
 
     op.drop_column("project_has_associated_user", 'role')
 


### PR DESCRIPTION
adds a default role in the migration makings sure all rows will have a role and throws a NotFound error if a user try's to add a associated_user to a project with an invalid role 