### PR TITLE
fixed create_project

### DIFF
--- a/amanuensis/resources/userdatamodel/userdatamodel_project.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_project.py
@@ -101,7 +101,9 @@ def create_project(current_session, user_id, description, name, institution, sea
     current_session.flush()
     new_project.searches.extend(searches)
     new_project.requests.extend(requests)
-    new_project.associated_users.extend(associated_users)
+    role_id = current_session.query(AssociatedUserRoles.id).filter(AssociatedUserRoles.code == "METADATA_ACCESS").first()[0]
+    for associated_user in associated_users:
+        new_project.project_has_associated_user.append(ProjectAssociatedUser(associated_user=associated_user, role_id=role_id))
 
     # current_session.flush()
     # current_session.add(new_project)

--- a/amanuensis/resources/userdatamodel/userdatamodel_project.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_project.py
@@ -3,7 +3,7 @@ import amanuensis
 
 from sqlalchemy.orm import aliased
 
-
+from cdislogging import get_logger
 from amanuensis.errors import NotFound, UserError
 from amanuensis.models import (
     Project,
@@ -17,6 +17,8 @@ from amanuensis.models import (
 from amanuensis.resources.userdatamodel.userdatamodel_request import (
     get_requests_by_project_id,
 )
+
+logger = get_logger(__name__)
 
 __all__ = [
     "get_all_projects",
@@ -105,7 +107,8 @@ def create_project(current_session, user_id, description, name, institution, sea
     if role_id:
         for associated_user in associated_users:
             new_project.project_has_associated_user.append(ProjectAssociatedUser(associated_user=associated_user, role_id=role_id[0]))
-
+    else:
+        logger.error("no roles present for associated users, no assoicated users will be added to project")
     # current_session.flush()
     # current_session.add(new_project)
     # current_session.merge(new_project)

--- a/amanuensis/resources/userdatamodel/userdatamodel_project.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_project.py
@@ -101,9 +101,10 @@ def create_project(current_session, user_id, description, name, institution, sea
     current_session.flush()
     new_project.searches.extend(searches)
     new_project.requests.extend(requests)
-    role_id = current_session.query(AssociatedUserRoles.id).filter(AssociatedUserRoles.code == "METADATA_ACCESS").first()[0]
-    for associated_user in associated_users:
-        new_project.project_has_associated_user.append(ProjectAssociatedUser(associated_user=associated_user, role_id=role_id))
+    role_id = current_session.query(AssociatedUserRoles.id).filter(AssociatedUserRoles.code == "METADATA_ACCESS").first()
+    if role_id:
+        for associated_user in associated_users:
+            new_project.project_has_associated_user.append(ProjectAssociatedUser(associated_user=associated_user, role_id=role_id[0]))
 
     # current_session.flush()
     # current_session.add(new_project)


### PR DESCRIPTION
when a user creates a project from the create endpoint a role is now added in the project_has_associated_user table.

This way allows for associated users to be added to the associated user table. When querying the project that was added they appear still in the 'associated_users' list and roles are included in the project_has_associated_users