### PR TITLE
change logic when adding users in create project

### DIFF
--- a/amanuensis/resources/project/__init__.py
+++ b/amanuensis/resources/project/__init__.py
@@ -116,40 +116,15 @@ def create(logged_user_id, is_amanuensis_admin, name, description, filter_set_id
         req.states.append(default_state)
         requests.append(req)
 
-    # Check if associated_users exists in amanuensis
-    # 1. get associated_users from amanuensis
-    amanuensis_associated_users = get_all_associated_users(associated_users_emails)
-    # # 1. check if associated_users are already in amanuensis
-    # for associated_user in amanuensis_associated_users:
-    #     if associated_user.ema
-    # registered_stat = 
-    # missing_users_email = 
-
-    # # 2. Check if associated_user exists in fence. If so assign user_id, otherwise use the submitted email.
-    # fence_users = fence_get_users(config=config, usernames=associated_user_emails)
-    # fence_users = fence_users['users'] if 'users' in fence_users else []
-    
-    # 2. Check if any associated_user is not in the DB yet
-    missing_users_email = []
-    if len(associated_users_emails) != len(amanuensis_associated_users):
-        users_email = [user.email for user in amanuensis_associated_users]
-        missing_users_email = [email for email in associated_users_emails if email not in users_email]
-
-    # 3. link the existing statician to the project
-    associated_users = []
-    for user in amanuensis_associated_users:
-        associated_user = user
-        associated_users.append(associated_user)
-
-    # 4 or create them if they have not been previously
-    for user_email in missing_users_email:
-        associated_user = AssociatedUser(email=user_email)
-        associated_users.append(associated_user)
-
 
     with flask.current_app.db.session as session:
         project_schema = ProjectSchema()
-        project = create_project(session, logged_user_id, description, name, institution, filter_sets, requests, associated_users)
+        project = create_project(session, logged_user_id, description, name, institution, filter_sets, requests)
+        associated_users = []
+        for email in associated_users_emails:
+            associated_users.append({"project_id": project.id, "email": email})
+        associated_users.append({"project_id": project.id, "id": logged_user_id})
+        admin.add_associated_users(associated_users)
         project_schema.dump(project)
         return project
 

--- a/amanuensis/resources/userdatamodel/userdatamodel_project.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_project.py
@@ -88,7 +88,7 @@ def get_project_by_id(current_session, logged_user_id, project_id):
             AssociatedUser, ProjectAssociatedUser.associated_user, isouter=True).first()
 
 
-def create_project(current_session, user_id, description, name, institution, searches, requests, associated_users):
+def create_project(current_session, user_id, description, name, institution, searches, requests):
     """
     Creates a project with an associated auth_id and storage access
     """
@@ -104,12 +104,6 @@ def create_project(current_session, user_id, description, name, institution, sea
     current_session.flush()
     new_project.searches.extend(searches)
     new_project.requests.extend(requests)
-    role = get_associated_user_role_by_code(config["ASSOCIATED_USER_ROLE_DEFAULT"], current_session, throw_error=False)
-    if role:
-        for associated_user in associated_users:
-            new_project.project_has_associated_user.append(ProjectAssociatedUser(associated_user=associated_user, role_id=role.id))
-    else:
-        logger.error("no roles present for associated users, no assoicated users will be added to project")
     # current_session.flush()
     # current_session.add(new_project)
     # current_session.merge(new_project)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2348,7 +2348,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "userportaldatamodel"
-version = "1.4.1"
+version = "1.6.1"
 description = ""
 optional = false
 python-versions = "*"
@@ -2364,8 +2364,8 @@ sqlalchemy = ">=1.3.3,<1.4.0"
 [package.source]
 type = "git"
 url = "https://github.com/chicagopcdc/userPortalDataModel.git"
-reference = "1.6.0"
-resolved_reference = "886a5c9c2f42b68d72504465fd515582bc209533"
+reference = "1.6.1"
+resolved_reference = "58d47c6c51d55673ae87c966ed96e8a41802f912"
 
 [[package]]
 name = "werkzeug"
@@ -2509,4 +2509,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "863cd0434c1caa3c0a9a9c27b6cbe74ae0bb0d83e06aa4c09f74eee5f1a4e192"
+content-hash = "65b58800bc63d4caa393c60cd81c6bf14bba43b528ecc01d0ad7fa293e723073"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pcdcutils = {git = "https://github.com/chicagopcdc/pcdcutils.git", rev = "0.1.3"
 # userportaldatamodel = {git = "https://github.com/chicagopcdc/userPortalDataModel.git", rev = "pcdc_dev"}
 hubspotclient = {git = "https://github.com/chicagopcdc/hubspotclient.git", rev = "1.0.2"}
 pcdc-aws-client = {git = "https://github.com/chicagopcdc/pcdc-aws-client.git", rev = "1.2.4"}
-userportaldatamodel = {git = "https://github.com/chicagopcdc/userPortalDataModel.git", rev = "1.6.0"}
+userportaldatamodel = {git = "https://github.com/chicagopcdc/userPortalDataModel.git", rev = "1.6.1"}
 
 [tool.poetry.dev-dependencies]
 addict = "^2.2.1"

--- a/tests_endpoints/endpoints/test_build_project.py
+++ b/tests_endpoints/endpoints/test_build_project.py
@@ -107,347 +107,361 @@ def test_2_create_project_with_one_request(session, client):
     session.add_all([admin, user_2])
     session.commit()
 
-    
-    with patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
+    with patch("amanuensis.resources.admin.admin_associated_user.fence.fence_get_users", side_effect=fence_get_users_mock):
+        with patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
+            
+            """
+            user_1 creates a filterset
+            """
+
+            filter_set_create_json = {
+                "name":"test_filter_set",
+                "description":"",
+                "filters":{"__combineMode":"AND","__type":"STANDARD","value":{"consortium":{"__type":"OPTION","selectedValues":["INSTRuCT"],"isExclusion":False},"sex":{"__type":"OPTION","selectedValues":["Male"],"isExclusion":False}}},
+                "gqlFilter":{"AND":[{"IN":{"consortium":["INSTRuCT"]}},{"IN":{"sex":["Male"]}}]}
+            }
+            filter_set_create_response = client.post(f'/filter-sets?explorerId=1', json=filter_set_create_json)
+            assert filter_set_create_response.status_code == 200
+
+            """
+            user_1 sends a request to reterive the id of that filterset
+            """
+
+            filter_set_get_response = client.get('/filter-sets?explorerId=1')
+            assert filter_set_get_response.status_code == 200
+
+
+            id = filter_set_get_response.json["filter_sets"][0]["id"]
+
+            """
+            user_1 creates a snapshot of the filterset to share with user_2
+            """
+
+            filter_set_snapshot_json = {
+                "filterSetId": id
+            }
+            snapshot_response = client.post("/filter-sets/snapshot", json=filter_set_snapshot_json)
+            assert snapshot_response.status_code == 200
+
+            """
+            trigger Usererror test
+            """
+            response = client.post("/filter-sets/snapshot", json={})
+            assert response.status_code == 400
+
+        """
+        user_2 access filter_set
+        """
+
+        with patch('amanuensis.blueprints.filterset.current_user', id=102, username="endpoint_user_2@test.com"):
+            #other user gets snapshot
+            
+            get_snapshot_response = client.get(f"/filter-sets/snapshot/{snapshot_response.json}")
+            assert get_snapshot_response.status_code == 200
+            #assert get_snapshot_response.json["name"] == id
+        
         
         """
-        user_1 creates a filterset
+        user_2 wants user_1 to make a change to the filter_set
         """
 
-        filter_set_create_json = {
-            "name":"test_filter_set",
-            "description":"",
-            "filters":{"__combineMode":"AND","__type":"STANDARD","value":{"consortium":{"__type":"OPTION","selectedValues":["INSTRuCT"],"isExclusion":False},"sex":{"__type":"OPTION","selectedValues":["Male"],"isExclusion":False}}},
-            "gqlFilter":{"AND":[{"IN":{"consortium":["INSTRuCT"]}},{"IN":{"sex":["Male"]}}]}
-        }
-        filter_set_create_response = client.post(f'/filter-sets?explorerId=1', json=filter_set_create_json)
-        assert filter_set_create_response.status_code == 200
-
-        """
-        user_1 sends a request to reterive the id of that filterset
-        """
-
-        filter_set_get_response = client.get('/filter-sets?explorerId=1')
-        assert filter_set_get_response.status_code == 200
+        with patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
+            filter_set_change_json = {
+                "description":"",
+                "ids":None,
+                "name":"test_filter_set",
+                "filters":{"__combineMode":"AND","__type":"STANDARD","value":{"consortium":{"__type":"OPTION","isExclusion":False,"selectedValues":["INSTRuCT"]},"sex":{"__type":"OPTION","isExclusion":False,"selectedValues":["Male","Female"]}}},
+                "gqlFilter":{"AND":[{"IN":{"consortium":["INSTRuCT"]}},{"IN":{"sex":["Male","Female"]}}]}
+            }
+            filter_set_create_response = client.put(f'/filter-sets/{id}?explorerId=1', json=filter_set_change_json)
+            assert filter_set_create_response.status_code == 200
 
 
-        id = filter_set_get_response.json["filter_sets"][0]["id"]
-
-        """
-        user_1 creates a snapshot of the filterset to share with user_2
-        """
-
-        filter_set_snapshot_json = {
-            "filterSetId": id
-        }
-        snapshot_response = client.post("/filter-sets/snapshot", json=filter_set_snapshot_json)
-        assert snapshot_response.status_code == 200
-
-        """
-        trigger Usererror test
-        """
-        response = client.post("/filter-sets/snapshot", json={})
-        assert response.status_code == 400
-
-    """
-    user_2 access filter_set
-    """
-
-    with patch('amanuensis.blueprints.filterset.current_user', id=102, username="endpoint_user_2@test.com"):
-        #other user gets snapshot
-        
-        get_snapshot_response = client.get(f"/filter-sets/snapshot/{snapshot_response.json}")
-        assert get_snapshot_response.status_code == 200
-        #assert get_snapshot_response.json["name"] == id
-    
-    
-    """
-    user_2 wants user_1 to make a change to the filter_set
-    """
-
-    with patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
-        filter_set_change_json = {
-            "description":"",
-            "ids":None,
-            "name":"test_filter_set",
-            "filters":{"__combineMode":"AND","__type":"STANDARD","value":{"consortium":{"__type":"OPTION","isExclusion":False,"selectedValues":["INSTRuCT"]},"sex":{"__type":"OPTION","isExclusion":False,"selectedValues":["Male","Female"]}}},
-            "gqlFilter":{"AND":[{"IN":{"consortium":["INSTRuCT"]}},{"IN":{"sex":["Male","Female"]}}]}
-        }
-        filter_set_create_response = client.put(f'/filter-sets/{id}?explorerId=1', json=filter_set_change_json)
-        assert filter_set_create_response.status_code == 200
+        with \
+        patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
+        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRUCT"]):
 
 
-    with \
-    patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
-    patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRUCT"]):
+            """
+            admin fetches the filter sets from user_1
+            """
 
+            admin_get_filter_sets_json = {"user_id": 101}
+            admin_get_filter_sets = client.get("/admin/filter-sets/user", json=admin_get_filter_sets_json)
+            assert admin_get_filter_sets.status_code == 200
+            assert admin_get_filter_sets.json["filter_sets"][0]['id'] == id
+            
+            """
+            ERROR TEST
+            """
+            error_response = client.get("/admin/filter-sets/user", json={})
+            assert error_response.status_code == 400
 
-        """
-        admin fetches the filter sets from user_1
-        """
+            """
+            admin creates a new project
+            """
+            #admin is already in table
+            #user1 is in fence but not table
+            #user5 is in neither
+            create_project_json = {
+                "user_id": 101,
+                "name": "Test Project",
+                "description": "This is an endpoint test project",
+                "institution": "test university",
+                "filter_set_ids": [admin_get_filter_sets.json["filter_sets"][0]['id']],
+                "associated_users_emails": ["endpoint_user_1@test.com", "admin@uchicago.edu", "endpoint_user_5@test.com"]
 
-        admin_get_filter_sets_json = {"user_id": 101}
-        admin_get_filter_sets = client.get("/admin/filter-sets/user", json=admin_get_filter_sets_json)
-        assert admin_get_filter_sets.status_code == 200
-        assert admin_get_filter_sets.json["filter_sets"][0]['id'] == id
-        
-        """
-        ERROR TEST
-        """
-        error_response = client.get("/admin/filter-sets/user", json={})
-        assert error_response.status_code == 400
+            }
+            create_project_response = client.post('/admin/projects', json=create_project_json)
+            assert create_project_response.status_code == 200
+            project_id = create_project_response.json['id']
 
-        """
-        admin creates a new project
-        """
+            """
+            TEST ERROR
+            """
+            error_response  = client.post('/admin/projects', json={})
+            assert error_response.status_code == 400
 
-        create_project_json = {
-            "user_id": 101,
-            "name": "Test Project",
-            "description": "This is an endpoint test project",
-            "institution": "test university",
-            "filter_set_ids": [admin_get_filter_sets.json["filter_sets"][0]['id']],
-            "associated_users_emails": ["endpoint_user_1@test.com", "admin@uchicago.edu"]
+            with patch('amanuensis.resources.project.get_consortium_list', return_value=["bad"]):
+                error_response = client.post('/admin/projects', json=create_project_json)
+                assert error_response.status_code == 404
+            
 
-        }
-        create_project_response = client.post('/admin/projects', json=create_project_json)
-        assert create_project_response.status_code == 200
-        project_id = create_project_response.json['id']
-
-        """
-        TEST ERROR
-        """
-        error_response  = client.post('/admin/projects', json={})
-        assert error_response.status_code == 400
-
-        with patch('amanuensis.resources.project.get_consortium_list', return_value=["bad"]):
-            error_response = client.post('/admin/projects', json=create_project_json)
-            assert error_response.status_code == 404
-        
-
-        
-        """
-        add user_2 to the project with data access
-        """
-        with patch("amanuensis.resources.admin.admin_associated_user.fence.fence_get_users", side_effect=fence_get_users_mock):
+            
+            """
+            add user_2 to the project with data access
+            """
             add_user_2_response = client.post("/admin/associated_user", json={"users": [{"project_id": project_id, "email": 'endpoint_user_2@test.com'}], "role": "DATA_ACCESS"})
             add_user_2_response.status_code == 200
-        
-        """
-        add user_3 to the project with metadata access
-        """
-        
-        with patch("amanuensis.resources.admin.admin_associated_user.fence.fence_get_users", side_effect=fence_get_users_mock):
+            
+            """
+            add user_3 to the project with metadata access
+            """
+            
             add_user_3_response = client.post("/admin/associated_user", json={"users": [{"project_id": project_id, "email": 'endpoint_user_3@test.com'}]})
             add_user_3_response.status_code == 200
-        
+            
 
-        """
-        send a request to reterive all the possible roles
-        """
-        roles_response = client.get("/admin/all_associated_user_roles")
-        assert roles_response.status_code == 200
-        data_access = roles_response.json["DATA_ACCESS"]
+            """
+            send a request to reterive all the possible roles
+            """
+            roles_response = client.get("/admin/all_associated_user_roles")
+            assert roles_response.status_code == 200
+            data_access = roles_response.json["DATA_ACCESS"]
 
-        """
-        change user_1's role to Data Access
-        """
-        user_1_data_acess_json = {
-            "user_id": 101,
-            "email": "endpoint_user_1@test.com",
-            "project_id": project_id,
-            "role": data_access
-        }
-        user_1_data_acess_response = client.put("/admin/associated_user_role", json=user_1_data_acess_json)
-        assert user_1_data_acess_response.status_code == 200
-        
-        user_3_data_acess_json = {
-            "user_id": 103,
-            "email": "endpoint_user_3@test.com",
-            "project_id": project_id,
-            "role": data_access
-        }
-        user_3_data_acess_response = client.put("/admin/associated_user_role", json=user_3_data_acess_json)
-        assert user_3_data_acess_response.status_code == 200
-
-
-        """
-        remove user_3 from the project
-        """
-        user_3_delete_json = {
-            "user_id": 103,
-            "email": "endpoint_user_3@test.com",
-            "project_id": project_id,
-        }
-        user_3_delete_response = client.delete("/admin/associated_user_role", json=user_3_delete_json)
-        assert user_3_delete_response.status_code == 200
+            """
+            change user_1's role to Data Access
+            """
+            user_1_data_acess_json = {
+                "user_id": 101,
+                "email": "endpoint_user_1@test.com",
+                "project_id": project_id,
+                "role": data_access
+            }
+            user_1_data_acess_response = client.put("/admin/associated_user_role", json=user_1_data_acess_json)
+            assert user_1_data_acess_response.status_code == 200
+            
+            user_3_data_acess_json = {
+                "user_id": 103,
+                "email": "endpoint_user_3@test.com",
+                "project_id": project_id,
+                "role": data_access
+            }
+            user_3_data_acess_response = client.put("/admin/associated_user_role", json=user_3_data_acess_json)
+            assert user_3_data_acess_response.status_code == 200
 
 
-
-        """
-        send a request to retreve all availble options for project states
-        """
-
-
-        revision_state = None
-        approved_state = None
-        data_available = None
-        get_states_response = client.get("/admin/states")
-        for state in get_states_response.json:
-            if state["code"] == "REVISION":
-                revision_state = state
-            elif state["code"] == "APPROVED":
-                approved_state = state
-            elif state["code"] == "DATA_AVAILABLE":
-                data_available = state 
+            """
+            remove user_3 from the project
+            """
+            user_3_delete_json = {
+                "user_id": 103,
+                "email": "endpoint_user_3@test.com",
+                "project_id": project_id,
+            }
+            user_3_delete_response = client.delete("/admin/associated_user_role", json=user_3_delete_json)
+            assert user_3_delete_response.status_code == 200
 
 
 
-
-        """
-        the EC committe requires the users to change their filter set, move state to revision
-        """
-
-        update_project_state_revison_json = {"project_id": project_id, "state_id": revision_state["id"]}
-        update_project_state_revison_response = client.post("/admin/projects/state", json=update_project_state_revison_json)
-        update_project_state_revison_response.status_code == 200
+            """
+            send a request to retreve all availble options for project states
+            """
 
 
-
-        """
-        admin creates a filter_set with the corrections
-        """
-        admin_create_filter_set_json = {
-            "user_id": 200,
-            "name":"test_filter_set_correction",
-            "description":"",
-            "filters":{"AND":[{"IN":{"consortium":["INSTRuCT"]}}]}
-        }
-        admin_create_filter_set_response = client.post("/admin/filter-sets", json=admin_create_filter_set_json)
-        assert admin_create_filter_set_response.status_code == 200
-
-        admin_filterset_id = admin_create_filter_set_response.json["id"]
-
-        """
-        TEST ERROR no user_id
-        """
-        
-        error_response  = client.post("/admin/filter-sets", json={})
-        assert error_response.status_code == 400
-
-        """
-        admin copies new search to user_1
-        """
-
-        admin_copy_search_to_user_json = {
-            "filtersetId": admin_filterset_id,
-            "userId": 101
-        }
-        admin_copy_search_to_user_response = client.post("admin/copy-search-to-user", json=admin_copy_search_to_user_json)
-        admin_copy_search_to_user_response.status_code == 200
-
-
-        
-        """
-        admin copies new search to the project
-        """
-
-        admin_copy_search_to_project_json = {
-            "filtersetId": admin_filterset_id,
-            "projectId": project_id
-        }
-        admin_copy_search_to_project_response = client.post("admin/copy-search-to-project", json=admin_copy_search_to_project_json)
-        assert admin_copy_search_to_project_response.status_code == 200
+            revision_state = None
+            approved_state = None
+            data_available = None
+            get_states_response = client.get("/admin/states")
+            for state in get_states_response.json:
+                if state["code"] == "REVISION":
+                    revision_state = state
+                elif state["code"] == "APPROVED":
+                    approved_state = state
+                elif state["code"] == "DATA_AVAILABLE":
+                    data_available = state 
 
 
 
-        """
-        move project state to approved
-        """
 
-        update_project_state_approved_json = {"project_id": project_id, "state_id": approved_state["id"]}
-        update_project_state_approved_response = client.post("/admin/projects/state", json=update_project_state_approved_json)
-        assert update_project_state_approved_response.status_code == 200
+            """
+            the EC committe requires the users to change their filter set, move state to revision
+            """
 
-        """
-        add approved_url to project
-        """
-        update_project_json = {
-            "project_id": project_id,
-            "approved_url": "http://approved.com"
-        }
-        update_project_response = client.put("/admin/projects", json=update_project_json)
-        assert update_project_response.status_code == 200
-
-        """
-        Error test
-        """
-        #assert client.put("/admin/projects", json={}).status_code == 400
-
-        """
-        patch project date
-        """
-        #BUG test current disabled do to bug
-        # current_time = datetime.now()
-        # patch_project_date_json = {
-        #     "project_id": project_id,
-        #     "year": current_time.year,
-        #     "month": current_time.month,
-        #     "day": current_time.day
-        # }
-        # patch_project_date_response = client.patch("/admin/projects/date", json=patch_project_date_json)
-        # assert patch_project_date_response.status_code == 200
+            update_project_state_revison_json = {"project_id": project_id, "state_id": revision_state["id"]}
+            update_project_state_revison_response = client.post("/admin/projects/state", json=update_project_state_revison_json)
+            update_project_state_revison_response.status_code == 200
 
 
-        """
-        move state to data availble
-        """
 
-        update_project_state_data_available_json = {"project_id": project_id, "state_id": data_available["id"]}
-        update_project_state_data_available_response = client.post("/admin/projects/state", json=update_project_state_data_available_json)
-        update_project_state_data_available_response.status_code == 200
+            """
+            admin creates a filter_set with the corrections
+            """
+            admin_create_filter_set_json = {
+                "user_id": 200,
+                "name":"test_filter_set_correction",
+                "description":"",
+                "filters":{"AND":[{"IN":{"consortium":["INSTRuCT"]}}]}
+            }
+            admin_create_filter_set_response = client.post("/admin/filter-sets", json=admin_create_filter_set_json)
+            assert admin_create_filter_set_response.status_code == 200
 
-        """
-        error test
-        """
-        #assert client.post("/admin/projects/state", json={}).status_code == 400
+            admin_filterset_id = admin_create_filter_set_response.json["id"]
 
-    with \
-    patch('amanuensis.blueprints.download_urls.current_user', id=102, username="endpoint_user_2@test.com"), \
-    patch('amanuensis.blueprints.download_urls.get_s3_key_and_bucket', return_value={"bucket": "test_bucket", "key": "test_key"}):
-        """
-        get download url
-        """
-        get_download_url_response = client.get(f"/download-urls/{project_id}")
-        assert get_download_url_response.status_code == 200
+            """
+            TEST ERROR no user_id
+            """
+            
+            error_response  = client.post("/admin/filter-sets", json={})
+            assert error_response.status_code == 400
+
+            """
+            admin copies new search to user_1
+            """
+
+            admin_copy_search_to_user_json = {
+                "filtersetId": admin_filterset_id,
+                "userId": 101
+            }
+            admin_copy_search_to_user_response = client.post("admin/copy-search-to-user", json=admin_copy_search_to_user_json)
+            admin_copy_search_to_user_response.status_code == 200
+
+
+            
+            """
+            admin copies new search to the project
+            """
+
+            admin_copy_search_to_project_json = {
+                "filtersetId": admin_filterset_id,
+                "projectId": project_id
+            }
+            admin_copy_search_to_project_response = client.post("admin/copy-search-to-project", json=admin_copy_search_to_project_json)
+            assert admin_copy_search_to_project_response.status_code == 200
+
+
+
+            """
+            move project state to approved
+            """
+
+            update_project_state_approved_json = {"project_id": project_id, "state_id": approved_state["id"]}
+            update_project_state_approved_response = client.post("/admin/projects/state", json=update_project_state_approved_json)
+            assert update_project_state_approved_response.status_code == 200
+
+            """
+            add approved_url to project
+            """
+            update_project_json = {
+                "project_id": project_id,
+                "approved_url": "http://approved.com"
+            }
+            update_project_response = client.put("/admin/projects", json=update_project_json)
+            assert update_project_response.status_code == 200
+
+            """
+            Error test
+            """
+            #assert client.put("/admin/projects", json={}).status_code == 400
+
+            """
+            patch project date
+            """
+            #BUG test current disabled do to bug
+            # current_time = datetime.now()
+            # patch_project_date_json = {
+            #     "project_id": project_id,
+            #     "year": current_time.year,
+            #     "month": current_time.month,
+            #     "day": current_time.day
+            # }
+            # patch_project_date_response = client.patch("/admin/projects/date", json=patch_project_date_json)
+            # assert patch_project_date_response.status_code == 200
+
+
+            """
+            move state to data availble
+            """
+
+            update_project_state_data_available_json = {"project_id": project_id, "state_id": data_available["id"]}
+            update_project_state_data_available_response = client.post("/admin/projects/state", json=update_project_state_data_available_json)
+            update_project_state_data_available_response.status_code == 200
+
+            """
+            error test
+            """
+            #assert client.post("/admin/projects/state", json={}).status_code == 400
+
+        with \
+        patch('amanuensis.blueprints.download_urls.current_user', id=102, username="endpoint_user_2@test.com"), \
+        patch('amanuensis.blueprints.download_urls.get_s3_key_and_bucket', return_value={"bucket": "test_bucket", "key": "test_key"}):
+            """
+            get download url
+            """
+            get_download_url_response = client.get(f"/download-urls/{project_id}")
+            assert get_download_url_response.status_code == 200
 
 
         """
         run all three get project requests
         """
-    with \
-    patch('amanuensis.blueprints.project.current_user', id=101, username="endpoint_user_1@test.com"), \
-    patch('amanuensis.blueprints.project.has_arborist_access', return_value=False), \
-    patch("amanuensis.blueprints.project.fence_get_users", side_effect=fence_get_users_mock):
-        get_project_user_1_response = client.get("/projects", headers={"Authorization": 'bearer 1.2.3'})
-        assert get_project_user_1_response.status_code == 200
-        user_1_first_login = session.query(AssociatedUser).filter(AssociatedUser.email == "endpoint_user_1@test.com").first()
-        assert user_1_first_login.user_id == 101
+        #user 5 logs in for first time user_id should be updated in associated_user table
+        fence_user_5 = {
+            "users": [
+                {
+                    "first_name": "endpoint_5_first",
+                    "id": 105,
+                    "institution": "uchicago",
+                    "last_auth": "Fri, 20 Jan 2024 20:33:37 GMT",
+                    "last_name": "endpoint_5_last",
+                    "name": "endpoint_user_5@test.com",
+                    "role": "user"
+                }
+            ]
+        }
+        with \
+        patch('amanuensis.blueprints.project.current_user', id=105, username="endpoint_user_5@test.com"), \
+        patch('amanuensis.blueprints.project.has_arborist_access', return_value=False), \
+        patch("amanuensis.blueprints.project.fence_get_users", return_value=fence_user_5):
+            get_project_user_1_response = client.get("/projects", headers={"Authorization": 'bearer 1.2.3'})
+            assert get_project_user_1_response.status_code == 200
+            user_1_first_login = session.query(AssociatedUser).filter(AssociatedUser.email == "endpoint_user_5@test.com").first()
+            assert user_1_first_login.user_id == 105
 
 
-    with patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
-        """
-        user_1 gets the filterset with the filterset id
-        """
-        get_filter_set_id_response = client.get(f"filter-sets/{id}?explorerId=1")
-        assert get_filter_set_id_response.status_code == 200
+        with patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
+            """
+            user_1 gets the filterset with the filterset id
+            """
+            get_filter_set_id_response = client.get(f"filter-sets/{id}?explorerId=1")
+            assert get_filter_set_id_response.status_code == 200
 
 
-        """
-        user_1 deletes the filterset as the project is now complete
-        """
-        delete_filter_set = client.delete(f"filter-sets/{id}?explorerId=1")
-        assert delete_filter_set.status_code == 200 
+            """
+            user_1 deletes the filterset as the project is now complete
+            """
+            delete_filter_set = client.delete(f"filter-sets/{id}?explorerId=1")
+            assert delete_filter_set.status_code == 200 
     
 
 


### PR DESCRIPTION
post admin/project and post /project routes, now use the logic that add_associated_users route uses. when creating a project the the owner of the project will automatically be added to associated_users_emails list via the user_id. the user_id field will now be filled out if the associated_user_email exists in fence. this also fixes a small bug when a associated user is added to multiple projects without signing into fence first.