### PR TITLE
seperate change role and divide

### DIFF
--- a/amanuensis/blueprints/admin.py
+++ b/amanuensis/blueprints/admin.py
@@ -250,6 +250,8 @@ def delete_user_from_project():
     project_id = request.get_json().get("project_id", None)
     if not project_id:
         raise UserError("A project is nessary for this endpoint")
+    if not project.get_by_id(None, project_id):
+        raise NotFound("the project provided does not exist")
     return jsonify(admin.delete_user_from_project(project_id, associated_user_id, associated_user_email))
 
 
@@ -270,6 +272,8 @@ def update_associated_user_role():
     project_id = request.get_json().get("project_id", None)
     if not project_id:
         raise UserError("A project is nessary for this endpoint")
+    if not project.get_by_id(None, project_id):
+        raise NotFound("the project provided does not exist")
     role = request.get_json().get("role", None)     
     if not role:
         raise UserError("A role is required for this endpoint")

--- a/amanuensis/blueprints/admin.py
+++ b/amanuensis/blueprints/admin.py
@@ -240,7 +240,20 @@ def update_project_state():
 def get_all_associated_user_roles():
     return jsonify(admin.get_codes_for_roles())
 
-@blueprint.route("/associated_user_role", methods=["PUT", "DELETE"])
+@blueprint.route("/remove_associated_user_from_project", methods=["DELETE"])
+@check_arborist_auth(resource="/services/amanuensis", method="*")
+def delete_user_from_project():
+    associated_user_id = request.get_json().get("user_id", None)
+    associated_user_email = request.get_json().get("email", None)
+    if not associated_user_id and not associated_user_email:
+        raise UserError("A user_id and or an associated_user_email is required for this endpoint.")
+    project_id = request.get_json().get("project_id", None)
+    if not project_id:
+        raise UserError("A project is nessary for this endpoint")
+    return jsonify(admin.delete_user_from_project(project_id, associated_user_id, associated_user_email))
+
+
+@blueprint.route("/associated_user_role", methods=["PUT"])
 @check_arborist_auth(resource="/services/amanuensis", method="*")
 # @debug_log
 def update_associated_user_role():
@@ -255,13 +268,13 @@ def update_associated_user_role():
         raise UserError("A user_id and or an associated_user_email is required for this endpoint.")
 
     project_id = request.get_json().get("project_id", None)
-    role = request.get_json().get("role", None)
-    if request.method == "PUT":     
-        if not role:
-            raise UserError("A role is required for this endpoint")
-        if role not in admin.get_codes_for_roles():
-            raise NotFound("The role {} is not in the allowed list, reach out to pcdc_help@lists.uchicago.edu".format(role))
-    
+    if not project_id:
+        raise UserError("A project is nessary for this endpoint")
+    role = request.get_json().get("role", None)     
+    if not role:
+        raise UserError("A role is required for this endpoint")
+    if role not in admin.get_codes_for_roles():
+        raise NotFound("The role {} is not in the allowed list, reach out to pcdc_help@lists.uchicago.edu".format(role))
     return jsonify(admin.update_role(project_id, associated_user_id, associated_user_email, role))
 
 

--- a/amanuensis/resources/admin/admin_associated_user.py
+++ b/amanuensis/resources/admin/admin_associated_user.py
@@ -17,12 +17,24 @@ __all__ = [
     "add_associated_users",
     "get_codes_for_roles",
     "update_associated_user_user_id",
+    "delete_user_from_project"
 ]
 
 
 def update_role(project_id, user_id, email, role):
     with flask.current_app.db.session as session:
-        ret = udm.update_associated_users(session, project_id, user_id, email, role)
+        user = udm.associate_user.get_project_assoicated_user(session, project_id, user_id, email)
+        if not user:
+            raise UserError("No user associated with project {} found.".format(project_id))
+        ret = udm.associate_user.update_user_role(session, user, role)
+        return ret
+
+def delete_user_from_project(project_id, user_id, email):
+    with flask.current_app.db.session as session:
+        user = udm.associate_user.get_project_assoicated_user(session, project_id, user_id, email)
+        if not user:
+            raise UserError("No user associated with project {} found.".format(project_id))
+        ret = udm.associate_user.change_project_user_status(session, user, False)
         return ret
 
 def get_codes_for_roles():
@@ -46,8 +58,6 @@ def add_associated_users(users, role=None):
     with flask.current_app.db.session as session:
         associated_user_schema = AssociatedUserSchema(many=True)
         ret = []
-        seen_ids = set()
-        seen_emails = set()
         for user in users:
             fence_user = None
             amanuensis_user = None
@@ -59,13 +69,9 @@ def add_associated_users(users, role=None):
             if "id" in user:
                 fence_user_by_id = fence.fence_get_users(config, ids=[user["id"]])["users"]
                 fence_user_by_id = fence_user_by_id[0] if len(fence_user_by_id) == 1 else None
-                if fence_user_by_id and (fence_user_by_id['id'] in seen_ids or fence_user_by_id["name"] in seen_emails):
-                    continue
             if "email" in user:
                 fence_user_by_email = fence.fence_get_users(config, usernames=[user["email"]])["users"]
                 fence_user_by_email = fence_user_by_email[0] if len(fence_user_by_email) == 1 else None
-                if fence_user_by_email and (fence_user_by_email['id'] in seen_ids or fence_user_by_email["name"] in seen_emails):
-                    continue  
             # Check for discrepancies in case the user submitted both id and email instead of just one of the two
             if fence_user_by_email and fence_user_by_id:
                 if fence_user_by_email["id"] != fence_user_by_id["id"] or fence_user_by_email["name"] != fence_user_by_id["name"]:
@@ -141,8 +147,6 @@ def add_associated_users(users, role=None):
                         role_id=role_id
                     )
                 )
-            seen_ids.add(user["id"])
-            seen_emails.add(user["email"])
 
         associated_user_schema.dump(ret)
         return ret

--- a/amanuensis/resources/admin/admin_associated_user.py
+++ b/amanuensis/resources/admin/admin_associated_user.py
@@ -23,7 +23,7 @@ __all__ = [
 
 def update_role(project_id, user_id, email, role):
     with flask.current_app.db.session as session:
-        user = udm.associate_user.get_project_assoicated_user(session, project_id, user_id, email)
+        user = udm.associate_user.get_project_associated_user(session, project_id, user_id, email)
         if not user:
             raise UserError("No user associated with project {} found.".format(project_id))
         ret = udm.associate_user.update_user_role(session, user, role)
@@ -31,7 +31,7 @@ def update_role(project_id, user_id, email, role):
 
 def delete_user_from_project(project_id, user_id, email):
     with flask.current_app.db.session as session:
-        user = udm.associate_user.get_project_assoicated_user(session, project_id, user_id, email)
+        user = udm.associate_user.get_project_associated_user(session, project_id, user_id, email)
         if not user:
             raise UserError("No user associated with project {} found.".format(project_id))
         ret = udm.associate_user.change_project_user_status(session, user, False)

--- a/amanuensis/resources/userdatamodel/userdatamodel_associated_user.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_associated_user.py
@@ -14,7 +14,7 @@ __all__ = [
     "update_associated_users",
     "add_associated_user",
     "add_associated_user_to_project",
-    "get_project_assoicated_user",
+    "get_project_associated_user",
     "change_project_user_status",
     "update_user_role"
 ]
@@ -90,7 +90,7 @@ def update_associated_users(current_session, associated_users):
 
     return "200"
 
-def get_project_assoicated_user(current_session, project_id, id=None, email=None):
+def get_project_associated_user(current_session, project_id, id=None, email=None):
     user_by_id = None
     user_by_email = None
 
@@ -161,7 +161,7 @@ def add_associated_user_to_project(current_session, associated_user, project_id,
         raise UserError("Missing user id.")
     
     #check if project_user already exists
-    user = get_project_assoicated_user(current_session, project_id, email=associated_user.email)
+    user = get_project_associated_user(current_session, project_id, email=associated_user.email)
     if user:
         if not user.active:
             change_project_user_status(current_session, user, True)

--- a/amanuensis/resources/userdatamodel/userdatamodel_associated_user.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_associated_user.py
@@ -1,5 +1,8 @@
 from amanuensis.errors import NotFound, UserError
 from amanuensis.models import AssociatedUser, ProjectAssociatedUser
+from amanuensis.resources.userdatamodel.userdatamodel_associated_user_roles import get_associated_user_role_by_code
+from amanuensis.config import config
+from cdislogging import get_logger
 
 __all__ = [
     "get_associated_user",
@@ -11,7 +14,12 @@ __all__ = [
     "update_associated_users",
     "add_associated_user",
     "add_associated_user_to_project",
+    "get_project_assoicated_user",
+    "change_project_user_status",
+    "update_user_role"
 ]
+
+logger = get_logger(logger_name=__name__)
 
 def get_associated_user(current_session, email):
     if not email:
@@ -82,6 +90,47 @@ def update_associated_users(current_session, associated_users):
 
     return "200"
 
+def get_project_assoicated_user(current_session, project_id, id=None, email=None):
+    user_by_id = None
+    user_by_email = None
+
+    if id:
+        user_by_id = current_session.query(ProjectAssociatedUser).filter(ProjectAssociatedUser.project_id == project_id).join(AssociatedUser, ProjectAssociatedUser.associated_user).filter(AssociatedUser.user_id == id).first()
+        # q = s.query(Parent).join(Child, Parent.child).filter(Child.value > 20)
+
+    if email:
+        user_by_email = current_session.query(ProjectAssociatedUser).filter(ProjectAssociatedUser.project_id == project_id).join(AssociatedUser, ProjectAssociatedUser.associated_user).filter(AssociatedUser.email == email).first()
+    
+    if not user_by_email and not user_by_id:
+        return
+    
+    if user_by_email and user_by_id and (user_by_email.associated_user.id != user_by_id.associated_user.id):
+        raise UserError(
+                "Invalid input - The ID and the email has to be for the same user. Only one is required. {} and {} don't match the same person in Fence.".format(id, email)
+            )
+
+    user = user_by_id if user_by_id else user_by_email
+
+    return user
+
+def update_user_role(current_session, project_associated_user, code):
+    role = get_associated_user_role_by_code(code, current_session=current_session)
+    if not project_associated_user.active:
+        raise UserError(f"{project_associated_user.associated_user.email} is no longer an associated user of this project, they must be re-added before changing their data access")
+    else:
+        project_associated_user.role = role
+    
+    current_session.flush()
+    return f"{project_associated_user.associated_user.email} now has {code}"
+
+def change_project_user_status(current_session, project_associated_user, status):
+    if not status:
+        update_user_role(current_session, project_associated_user, config["ASSOCIATED_USER_ROLE_DEFAULT"])
+    project_associated_user.active = status
+    current_session.flush()
+    return "{user} has been {condition}".format(user=project_associated_user.associated_user.email, condition=("added" if status else "removed"))
+
+
 
 def add_associated_user(current_session, project_id, email, user_id, role_id):
     if not user_id and not email: 
@@ -110,6 +159,14 @@ def add_associated_user(current_session, project_id, email, user_id, role_id):
 def add_associated_user_to_project(current_session, associated_user, project_id, role_id):
     if not associated_user and not associated_user.id:
         raise UserError("Missing user id.")
+    
+    #check if project_user already exists
+    user = get_project_assoicated_user(current_session, project_id, email=associated_user.email)
+    if user:
+        if not user.active:
+            change_project_user_status(current_session, user, True)
+            logger.info(f"{associated_user.email} has been readded to the project")
+        return user
 
     new_project_user = ProjectAssociatedUser(
         project_id = project_id,
@@ -120,3 +177,6 @@ def add_associated_user_to_project(current_session, associated_user, project_id,
     current_session.add(new_project_user)
     current_session.commit()
     return associated_user
+
+
+

--- a/amanuensis/resources/userdatamodel/userdatamodel_project.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_project.py
@@ -29,7 +29,6 @@ __all__ = [
     "get_project_by_id",
     "create_project",
     "update_project",
-    "update_associated_users",
     "update_project_date",
 ]
 
@@ -136,53 +135,10 @@ def update_project(current_session, project_id, approved_url=None, searches=None
         return {"code": 200, "updated": int(project_id)}
     else:
         return {
-            "code": 500,
+            "code": 500, 
             "error": "Nothing has been updated, check the logs to see what happened during the transaction.",
         }
 
-
-
-def update_associated_users(current_session, project_id, id, email, role):
-    user_by_id = None
-    user_by_email = None
-
-    if id:
-        user_by_id = current_session.query(ProjectAssociatedUser).filter(ProjectAssociatedUser.project_id == project_id).join(AssociatedUser, ProjectAssociatedUser.associated_user).filter(AssociatedUser.user_id == id).first()
-        # q = s.query(Parent).join(Child, Parent.child).filter(Child.value > 20)
-
-    if email:
-        user_by_email = current_session.query(ProjectAssociatedUser).filter(ProjectAssociatedUser.project_id == project_id).join(AssociatedUser, ProjectAssociatedUser.associated_user).filter(AssociatedUser.email == email).first()
-        # user_by_email = ccurrent_session.query(AssociatedUser).filter(
-        #     AssociatedUser.id == id
-        # ).join(Project, AssociatedUser.projects).filter(
-        #     Project.id == project_id
-        # ).first()
-
-    # print(user_by_id)
-    # print(user_by_email)
-    # print(email)
-    # print(id)
-    
-    new_role = get_associated_user_role_by_code(current_session=current_session, code=role, throw_error=False)
-
-    if user_by_id:
-        if role:
-            user_by_id.role = new_role
-            user_by_id.active = True
-        else:
-            user_by_id.active = False
-    elif user_by_email:
-        if role:
-            user_by_email.role = new_role
-            user_by_email.active = True
-        else:
-            user_by_email.active = False
-    else:
-        raise NotFound("No user associated with project {} found.".format(project_id))
-
-    #current_session.commit()
-    current_session.flush()
-    return "200"
 
 
 def update_project_date(session, project_id, new_update_date):


### PR DESCRIPTION
This PR solves a couple of problems:

1)  the routes for changing a user role and removing a user from a project have been separated
changing user role now checks if user is active first 
when user is delete their role is changed to metadata access

2) fixes bug when adding the same associated_user to project twice
   before adding a user to project, the method now checks the project_has_associated_user table 
   if row exists and active == False active will be changed to True and return
   if row exists and active == True nothing happens
   This also solves the problem if you try adding the same person in the same request and allows us to auto add the project 
   owner when creating a project