### PR TITLE
Peds 1157

### DIFF
--- a/amanuensis/blueprints/project.py
+++ b/amanuensis/blueprints/project.py
@@ -27,24 +27,6 @@ blueprint = flask.Blueprint("projects", __name__)
 
 logger = get_logger(__name__)
 
-# def determine_status_code(project_request_states):
-#     with flask.current_app.db.session as session:
-#         transition_table = get_transition_graph(session)
-#         final_states = get_final_states(session)
-
-#         def overall_status_code(states, visited):
-#             overall_project_state = None
-#             while states:
-#                 current_state = states[-1]
-
-#         return overall_status_code(final_states, {})
-
-
-
-       
-
-
-
 # cache = SimpleCache()
 def determine_status_code(this_project_requests_states):
     """

--- a/amanuensis/blueprints/project.py
+++ b/amanuensis/blueprints/project.py
@@ -27,6 +27,8 @@ blueprint = flask.Blueprint("projects", __name__)
 
 logger = get_logger(__name__)
 
+
+
 # cache = SimpleCache()
 def determine_status_code(this_project_requests_states):
     """
@@ -36,50 +38,43 @@ def determine_status_code(this_project_requests_states):
     then the status code will be "PENDING".
     """
     #run BFS on state flow chart
+    with flask.current_app.db.session as session:
+        final_states = get_final_states(session)
+        transition_graph = get_transition_graph(session, reverse=True)
     try: 
-        #check if withdrawal or Rejected are a state
-        if "WITHDRAWAL" in this_project_requests_states:
-                return {"status": "WITHDRAWAL"}
-            
-        if "REJECTED" in this_project_requests_states:
-            return {"status": "REJECTED"}
         
-        with flask.current_app.db.session as session:
-            seen_codes = set()
-            overall_project_state = None
-            #states_queue = [(id, code)]
-            states_queue = [(session.query(State.id).filter(State.code == "PUBLISHED").all()[0], "PUBLISHED")]
-            while states_queue and this_project_requests_states:
-                #pull out data of current state
-                current_state = states_queue.pop(0)
-                if current_state[1] not in seen_codes:
-                    #add state to seen
-                    seen_codes.add(current_state[1])
-                    #query parent states and add to queue
-                    parent_states_code_id = session.query(Transition.state_src_id, State.code).join(
-                                                            Transition, Transition.state_src_id == State.id
-                                                        ).filter(
-                                                            Transition.state_dst.has(id=current_state[0])
-                                                        ).all()
-                    states_queue.extend([state for state in parent_states_code_id])
-                    #change overall project status if applicable
-                    if current_state[1] in this_project_requests_states:
-                        this_project_requests_states.remove(current_state[1])
-                        if ((current_state[1] == "APPROVED" and overall_project_state == "APPROVED_WITH_FEEDBACK")    
-                            or (current_state[1] == "REVISION") and overall_project_state == "SUBMITTED"):
+        for final_state in final_states:
+            if final_state in this_project_requests_states:
+                return {"status": final_state}   
+             
+        overall_state = None
+        seen_codes = set()
+        states_queue = ["DATA_DOWNLOADED"]
+        while states_queue and this_project_requests_states:
+            current_state = states_queue.pop(0)
+            if current_state not in seen_codes:
+
+                seen_codes.add(current_state)
+
+                states_queue.extend(transition_graph[current_state] if current_state in transition_graph else [])
+                
+                if current_state in this_project_requests_states:
+
+                    this_project_requests_states.remove(current_state)
+
+                    if ((current_state == "APPROVED" and overall_state == "APPROVED_WITH_FEEDBACK")    
+                        or (current_state == "REVISION" and overall_state == "SUBMITTED")):
                             continue
-                        else:
-                            overall_project_state = current_state[1]
+                    else:
+                        overall_state = current_state
+                        
+        if this_project_requests_states:
+            logger.error(f"{this_project_requests_states} dont exist in transition table")
+            raise InternalError("")
+        
+        return {"status": overall_state}
 
-            if this_project_requests_states:
-                raise InternalError("{project_request_states} are not valid state(s)")
-
-            return {"status": overall_project_state}
-
-    except (KeyError, InternalError):
-        #  logger.error(
-        #     "Unable to load or find the consortium status"
-        #  )
+    except Exception:
         raise InternalError("Unable to load or find the consortium status")
 
 

--- a/amanuensis/resources/request/__init__.py
+++ b/amanuensis/resources/request/__init__.py
@@ -23,7 +23,10 @@ from amanuensis.resources.userdatamodel.userdatamodel_request import (
     get_request_by_id,
     get_requests,
 )
-from amanuensis.schema import RequestSchema
+from amanuensis.resources.userdatamodel.userdatamodel_state import (
+    get_latest_request_state_by_id
+)
+from amanuensis.schema import RequestSchema, RequestStateSchema
 
 # from pcdcutils.environment import is_env_enabled
 
@@ -67,23 +70,10 @@ def get_by_id(logged_user_id, request_id):
         return get_request_by_id(session, logged_user_id, request_id)
 
 
-def get_request_state(request_id, session=None):
-    if session:
-        return (
-            session.query(RequestState)
-            .filter(RequestState.request_id == request_id)
-            .order_by(RequestState.create_date.desc())
-            .first()
-            # .state
-        )
-    else:
-        with flask.current_app.db.session as session:
-            return (
-                session.query(RequestState)
-                .filter(RequestState.request_id == request_id)
-                .order_by(RequestState.create_date.desc())
-                .first()
-                # .state
-            )
+def get_latest_request_state(requests=None, request_ids=None):
+    with flask.current_app.db.session as session:
+        request_state_schema = RequestStateSchema(many=True)
+        latest_states = get_latest_request_state_by_id(session, requests=requests, request_ids=request_ids)
+        return request_state_schema.dump(latest_states)
 
         

--- a/amanuensis/resources/userdatamodel/userdatamodel_state.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_state.py
@@ -20,6 +20,8 @@ __all__ = [
     "update_project_state",
     "get_state_by_id",
     "get_state_by_code",
+    "get_final_states",
+    "get_transition_graph"
 ]
 
 logger = getLogger(__name__)
@@ -62,9 +64,60 @@ def notify_user_project_status_update(current_session, project_id, consortiums):
     return send_admin_message(project, consortiums, email_subject, email_body)
 
 
-def get_latest_request_state_by_id(current_session, request_id):
-    return current_session.query(RequestState).filter(RequestState.request_id == request_id).order_by(desc(RequestState.create_date)).first()
+def get_latest_request_state_by_id(current_session, requests=None, request_ids=[]):
+    #filter out any request whos state is depreicated
+    #requests are request objects
+    #request_ids are ints
+    if requests and request_ids:
+        logger.error("both request and request_ids were passed to get_latest_request_state_by_id returning []")
+        return []
+    elif request_ids:
+        request_ids = [request_ids] if not isinstance(request_ids, list) else request_ids
+    elif requests:
+        requests = [requests] if not isinstance(requests, list) else requests
+        request_ids = [request.id for request in requests]
+    else:
+        logger.error("No requests were passed to get_latest_request_state_by_id returning []")
+        return []
 
+    subquery = (
+        current_session.query(
+            RequestState.request_id,
+            func.max(RequestState.create_date).label("max_create_date")
+        )
+        .filter(RequestState.request_id.in_(request_ids))
+        .group_by(RequestState.request_id)
+        .subquery()
+    )
+
+    sq = aliased(subquery)
+    rs = aliased(RequestState)
+
+    result = (
+        current_session.query(rs)
+        .join(State, rs.state)
+        .filter(rs.request_id == sq.c.request_id, rs.create_date == sq.c.max_create_date)
+        .filter(State.code != "DEPRECATED")
+        .all()
+    )
+    return result
+
+def get_transition_graph(current_session):
+    src_state_alias = aliased(State)
+    dst_state_alias = aliased(State)
+
+    result = (
+        current_session.query(src_state_alias.code, dst_state_alias.code)
+                       .join(Transition, Transition.state_src_id == src_state_alias.id)
+                       .join(dst_state_alias, Transition.state_dst_id == dst_state_alias.id)
+                       .all()
+    )
+
+    transition_graph = {}
+    for src_state, dst_state in result:
+        transition_graph[src_state] = transition_graph.get(src_state, []).append(dst_state)
+    
+    return transition_graph
 
 def get_final_states(current_session):
     src_state_alias = aliased(State)
@@ -90,36 +143,33 @@ def update_project_state(
     """
     Updates the state for a project, including all requests in the project. Notifies users when the state changes to DATA_DELIVERED.
     """
-    updated = False
-    consortiums = []
     final_states = get_final_states(current_session)
-    for request in requests:
-        consortium = request.consortium_data_contributor.code
-        consortiums.append(consortium)
-        state_code = get_latest_request_state_by_id(current_session, request.id)
-
-        if state_code == state.code:
+    current_request_states = get_latest_request_state_by_id(current_session, requests)
+    updated_requests = []
+    for request_state in current_request_states:
+        if request_state.state.code == state.code:
             logger.info(
                 "Request {} is already in state {}. No need to change.".format(
-                    request.id, state.code
+                    request_state.request.id, state.code
                 )
             )
-        elif state_code in final_states:
+        elif request_state.state.code in final_states:
             raise UserError(
                 "Cannot change state of request {} from {} because it's a final state".format(
-                    request.id, state.code
+                    request_state.request.id, state.code
                 )
             )
         else:
-            update_request_state(current_session, request, state)
+            update_request_state(current_session, request_state.request, state)
+            updated_requests.append(request_state.request)
 
-    if state.code in config["NOTIFY_STATE"] and updated:
+    if state.code in config["NOTIFY_STATE"] and updated_requests:
         notify_user_project_status_update(
             current_session,
             project_id,
-            consortiums
+            [updated_request.consortium_data_contributor.code for updated_request in updated_requests]
         )
 
     current_session.flush()
-    return requests
+    return updated_requests
 #END TODO

--- a/amanuensis/resources/userdatamodel/userdatamodel_state.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_state.py
@@ -102,7 +102,9 @@ def get_latest_request_state_by_id(current_session, requests=None, request_ids=[
     )
     return result
 
-def get_transition_graph(current_session):
+def get_transition_graph(current_session, reverse=False):
+    #if reverse is true it will return the directed graph with every edge reversed
+
     src_state_alias = aliased(State)
     dst_state_alias = aliased(State)
 
@@ -114,8 +116,14 @@ def get_transition_graph(current_session):
     )
 
     transition_graph = {}
-    for src_state, dst_state in result:
-        transition_graph[src_state] = transition_graph.get(src_state, []).append(dst_state)
+    if reverse:
+        for src_state, dst_state in result:
+            transition_graph[dst_state] = transition_graph.get(dst_state, [])
+            transition_graph[dst_state].append(src_state)
+    else:
+        for src_state, dst_state in result:
+            transition_graph[src_state] = transition_graph.get(src_state, [])
+            transition_graph[src_state].append(dst_state)
     
     return transition_graph
 

--- a/amanuensis/schema.py
+++ b/amanuensis/schema.py
@@ -10,6 +10,7 @@ from userportaldatamodel.schemas.schemas import (
     AttributeListSchema,
     AttributeListValueSchema,
     InputTypeSchema,
-    AssociatedUserSchema
+    AssociatedUserSchema,
+    RequestStateSchema
 )
 

--- a/migrations/versions/91b6a04820cd_add_deprecated.py
+++ b/migrations/versions/91b6a04820cd_add_deprecated.py
@@ -1,0 +1,36 @@
+"""add_deprecated
+
+Revision ID: 91b6a04820cd
+Revises: 57bc0c5a9733
+Create Date: 2024-03-04 17:29:29.400433
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm.session import Session
+from userportaldatamodel.models import State
+
+# revision identifiers, used by Alembic.
+revision = '91b6a04820cd'
+down_revision = '57bc0c5a9733'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    session = Session(bind=conn)
+    
+    deprecated = State(name="DEPRECATED", code="DEPRECATED")
+
+    session.add(deprecated)
+
+    session.commit()
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    session = Session(bind=conn)
+    session.query(State).filter(State.code == "DEPRECATED").delete()
+    session.commit()

--- a/tests_endpoints/endpoints/conftest.py
+++ b/tests_endpoints/endpoints/conftest.py
@@ -56,6 +56,15 @@ def fence_users():
             "last_name": "admin_last",
             "name": "admin@uchicago.edu",
             "role": "admin"
+        },
+        {
+            "first_name": "endpoint_user_6",
+            "id": 106,
+            "institution": "test university",
+            "last_auth": "Fri, 19 Jan 2024 20:33:37 GMT",
+            "last_name": "endpoint_user_last_6",
+            "name": "endpoint_user_6@test.com",
+            "role": "user"
         }
     ]
 

--- a/tests_endpoints/endpoints/test_change_requests_with_new_filter_set.py
+++ b/tests_endpoints/endpoints/test_change_requests_with_new_filter_set.py
@@ -199,4 +199,5 @@ def test_change_requests_with_new_filter_set(app_instance, session, client, fenc
         
             get_project = client.get("/projects", headers={"Authorization": 'bearer 106'})
             assert get_project.json[0]["status"] == "In Review"
-            assert get_project.json[0]["consortia"] == ["INSTRUCT", "INRG"]
+            assert len(get_project.json[0]["consortia"]) == 2
+            assert set(get_project.json[0]["consortia"]) == set(["INSTRUCT", "INRG"])

--- a/tests_endpoints/endpoints/test_overall_project_status.py
+++ b/tests_endpoints/endpoints/test_overall_project_status.py
@@ -40,24 +40,24 @@ def test_published(client):
 
 def test_data_downloaded(client):
     with app.app_context():
-        assert determine_status_code({"PUBLISHED", "DATA_DOWNLOADED"}) == {"status": "DATA_DOWNLOADED"}
+        assert determine_status_code({"PUBLISHED", "DATA_DOWNLOADED"}) == {"status": "PUBLISHED"}
 
 def test_data_availble(client):
     with app.app_context():
-        assert determine_status_code({"PUBLISHED", "DATA_DOWNLOADED", "DATA_AVAILABLE"}) == {"status": "DATA_AVAILABLE"}
+        assert determine_status_code({ "DATA_DOWNLOADED", "DATA_AVAILABLE"}) == {"status": "DATA_AVAILABLE"}
 
 def test_aggrements_executed(client):
     with app.app_context():
-        assert determine_status_code({"PUBLISHED", "DATA_DOWNLOADED", "DATA_AVAILABLE", "AGREEMENTS_EXECUTED"}) == {"status": "AGREEMENTS_EXECUTED"}
+        assert determine_status_code({ "DATA_DOWNLOADED", "DATA_AVAILABLE", "AGREEMENTS_EXECUTED"}) == {"status": "AGREEMENTS_EXECUTED"}
 
 def test_aggrements_negociated(client):
     with app.app_context():
-        assert determine_status_code({"PUBLISHED", "DATA_DOWNLOADED", "DATA_AVAILABLE", 
+        assert determine_status_code({"DATA_DOWNLOADED", "DATA_AVAILABLE", 
                                       "AGREEMENTS_EXECUTED", "AGREEMENTS_NEGOTIATION"}) == {"status": "AGREEMENTS_NEGOTIATION"}
 
 def test_request_critiera_finilized(client):
     with app.app_context():
-        assert determine_status_code({"PUBLISHED", "DATA_DOWNLOADED", "DATA_AVAILABLE", 
+        assert determine_status_code({"DATA_DOWNLOADED", "DATA_AVAILABLE", 
                                         "AGREEMENTS_EXECUTED", "AGREEMENTS_NEGOTIATION",
                                         "REQUEST_CRITERIA_FINALIZED"}) == {"status": "REQUEST_CRITERIA_FINALIZED"}   
 
@@ -101,7 +101,7 @@ def test_Reject(client):
 
 def test_Reject_pub(client):
     with app.app_context():
-        assert determine_status_code({"APPROVED", "REVISION", "IN_REVIEW", "REJECTED", "PUBLISHED"}) == {"status": "REJECTED"}
+        assert determine_status_code({"APPROVED", "REVISION", "IN_REVIEW", "REJECTED", "PUBLISHED"})["status"] in {"PUBLISHED", "REJECTED"}
 
 def test_withdrawl(client):
     with app.app_context():
@@ -109,4 +109,4 @@ def test_withdrawl(client):
 
 def test_reject_withdrawl(client):
     with app.app_context():
-        assert determine_status_code({"WITHDRAWAL", "REJECTED"}) == {"status": "WITHDRAWAL"}
+        assert determine_status_code({"WITHDRAWAL", "REJECTED"})["status"] in {"REJECTED", "WITHDRAWAL"}


### PR DESCRIPTION
This PR creates a new state DEPRECATED and if a filter-set is change any request not part of the new filter-set gets a state of DEPRECATED. the only way to move out of deprecated is if the filter-set is changed again 

when querying the latest state of a request the method get_latest_request_state_by_id has been updated to filter out any requests which are in state deprecated

in get projects/ 
the requests are sent to get_latest_request_state_by_id so that any request in deprecated wont have its consortium code sent back in the response

in post projects/state 
all the requests that want to be change are first sent to get_latest_request_state_by_id so that we dont change any request in deprecated 