### PR TITLE
PEDS-1193 PEDS-1192 PEDS-1186

### DIFF
--- a/amanuensis/resources/project/__init__.py
+++ b/amanuensis/resources/project/__init__.py
@@ -155,7 +155,15 @@ def update_project_searches(logged_user_id, project_id, filter_sets_id):
         not_found_filter_set_ids = set(filter_sets_id) - set(filter_set.id for filter_set in filter_sets)
         if not_found_filter_set_ids:
             raise NotFound(f"filter-set-id(s), {not_found_filter_set_ids} do not exist")
+        
 
+        #remove any filter-sets currently part of proejects
+        current_filter_sets = {search.id for search in project.searches}
+        filter_sets = [search for search in filter_sets if search.id not in current_filter_sets]
+        if not filter_sets:
+            project_schema.dump(project)
+            return project
+        
         # TODO make this a config variable in amanuensis-config.yaml
         path = 'http://pcdcanalysistools-service/tools/stats/consortiums'
         new_consortiums = set()

--- a/amanuensis/resources/userdatamodel/userdatamodel_associated_user.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_associated_user.py
@@ -124,7 +124,10 @@ def update_user_role(current_session, project_associated_user, code):
     return f"{project_associated_user.associated_user.email} now has {code}"
 
 def change_project_user_status(current_session, project_associated_user, status):
+    
     if not status:
+        if project_associated_user.project.user_id == project_associated_user.associated_user.user_id:
+            raise UserError("You cannot remove the owner of the project")
         update_user_role(current_session, project_associated_user, config["ASSOCIATED_USER_ROLE_DEFAULT"])
     project_associated_user.active = status
     current_session.flush()

--- a/amanuensis/resources/userdatamodel/userdatamodel_state.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_state.py
@@ -49,7 +49,7 @@ def get_state_by_code(current_session, code):
 
 
 def get_all_states(current_session):
-    return current_session.query(State).all()
+    return current_session.query(State).filter(State.code != 'DEPRECATED').all()
 
 
 # TODO move these 2 functions in the resources, there is logic here, the userdatamodel folder should contain mostly DB operation

--- a/tests_endpoints/endpoints/test_build_project.py
+++ b/tests_endpoints/endpoints/test_build_project.py
@@ -26,6 +26,9 @@ def test_add_state(session, client):
     session.query(State).filter(State.code == "ENDPOINT_TEST").delete()
     session.commit()
 
+def test_get_states(client):
+    response = client.get("/admin/states", headers={"Authorization": 'bearer 200'})
+    assert 'DEPRECATED' not in [state['code'] for state in response.json]
 
 def test_2_create_project_with_one_request(session, client, fence_get_users_mock, fence_users):
     """
@@ -220,6 +223,19 @@ def test_2_create_project_with_one_request(session, client, fence_get_users_mock
             block_add_user_5_response = client.post("/admin/associated_user", json={"users": [{"project_id": project_id, "email": 'endpoint_user_5@test.com'}]}, headers={"Authorization": 'bearer 200'})
             block_add_user_5_response.status_code == 200
 
+            """
+            block removing project owner
+            """
+            user_1_delete_json = {
+                "user_id": 101,
+                "email": "endpoint_user_1@test.com",
+                "project_id": project_id,
+            }
+            user_1_delete_response = client.delete("/admin/remove_associated_user_from_project", json=user_1_delete_json, headers={"Authorization": 'bearer 200'})
+            assert user_1_delete_response.status_code == 400
+            session.refresh(user_1) 
+            assert user_1.active == True
+            assert user_1.role.code == "METADATA_ACCESS"
 
             
             """

--- a/tests_endpoints/endpoints/test_change_requests_with_new_filter_set.py
+++ b/tests_endpoints/endpoints/test_change_requests_with_new_filter_set.py
@@ -143,6 +143,9 @@ def test_change_requests_with_new_filter_set(app_instance, session, client, fenc
             admin_copy_search_to_project_response = client.post("admin/copy-search-to-project", json=admin_copy_search_to_project_json, headers={"Authorization": 'bearer 200'})
             assert admin_copy_search_to_project_response.status_code == 200
             
+            #TEST sending same request returns 200
+            admin_copy_search_to_project_response = client.post("admin/copy-search-to-project", json=admin_copy_search_to_project_json, headers={"Authorization": 'bearer 200'})
+            assert admin_copy_search_to_project_response.status_code == 200
 
             assert get_latest_state(INSTRUCT) == "IN_REVIEW"
             assert get_latest_state(INTERACT) == "DEPRECATED"


### PR DESCRIPTION
Deprecated no longer is return in get admin/states route

if a filter-set is sent to admin/copy-search-to-project and that filter-set is already part of the project it is ignored
(there is an issue with session when you try to add the same thing twice)

owner of project can no longer be removed from a project