### PR TITLE
automatically update consortium DB with consortia not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ alembic revision -m "add_save"
 
         make sure to use the path where the object is called not definied
 
-        example: patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT", "INRG"]) 
+        example: patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', ["INRG"]) 
 
 2)  Fence
     in tests_endpoints/endpoints.conftest there are two pytest fixtures that simulate calls to fence

--- a/amanuensis/config-default.yaml
+++ b/amanuensis/config-default.yaml
@@ -119,6 +119,8 @@ ENABLE_DB_MIGRATION: true
 # this is also why our BASE_URL default ends in /user
 APPLICATION_ROOT: '/amanuensis'
 
+GET_CONSORTIUMS_URL: 'http://pcdcanalysistools-service/tools/stats/consortiums'
+
 
 
 ########################################################################################

--- a/amanuensis/resources/consortium_data_contributor/__init__.py
+++ b/amanuensis/resources/consortium_data_contributor/__init__.py
@@ -5,6 +5,7 @@ from cdislogging import get_logger
 from amanuensis.resources.userdatamodel import (
     create_consortium,
     get_consotium_by_code,
+    get_consortiums_by_code
 )
 from amanuensis.resources import filterset
 from amanuensis.config import config
@@ -12,6 +13,8 @@ from amanuensis.errors import NotFound, Unauthorized, UserError, InternalError, 
 from amanuensis.models import (
     ConsortiumDataContributor
 )
+
+from amanuensis.utils import get_consortium_list
 
 
 logger = get_logger(__name__)
@@ -31,9 +34,37 @@ def get(code,session = None):
         with flask.current_app.db.session as session:
             return get_consotium_by_code(session, code=code)
 
+def get_consortiums_from_fitersets(filter_sets, session=None):
+    if not filter_sets:
+        return None
+    
+    consortiums_from_guppy = set()
 
+    return_consortiums = {}
 
+    #get consortiums in filter-sets from guppy
+    for s in filter_sets:
+        # Get a list of consortiums the cohort of data is from
+        # example or retuned values - consoritums = ['INRG']
+        # s.filter_object - you can use getattr to get the value or implement __getitem__ - https://stackoverflow.com/questions/11469025/how-to-implement-a-subscriptable-class-in-python-subscriptable-class-not-subsc
+        consortiums_from_guppy.update(consortium.upper() for consortium in get_consortium_list(s.graphql_object, s.ids_list))  
+    
+    with session if session else flask.current_app.db.session as session:
+        #find which consortiums already exist in DB
+        present_consortiums = get_consortiums_by_code(session, consortiums_from_guppy)
 
+        return_consortiums = {consortium.code: consortium for consortium in present_consortiums}
+
+        #find which consortiums do not exist in DB
+        new_consortiums = consortiums_from_guppy - return_consortiums.keys()
+
+        #add consortiums to DB that are not present
+        for code in new_consortiums:
+            return_consortiums[code] = create_consortium(session, code, code)
+
+    #return all consortiums from filter-sets
+    # consortiums = {consortium_code: consortium_object}
+    return return_consortiums
 
 
     

--- a/amanuensis/resources/userdatamodel/userdatamodel_consortium_data_contributor.py
+++ b/amanuensis/resources/userdatamodel/userdatamodel_consortium_data_contributor.py
@@ -4,10 +4,12 @@ from amanuensis.errors import NotFound, UserError
 from amanuensis.models import (
     ConsortiumDataContributor
 )
+from amanuensis.schema import ConsortiumDataContributorSchema
 
 __all__ = [
     "create_consortium",
     "get_consotium_by_code",
+    "get_consortiums_by_code",
 ]
 
 def create_consortium(current_session, code, name):
@@ -27,4 +29,6 @@ def get_consotium_by_code(current_session, code):
     return current_session.query(ConsortiumDataContributor).filter_by(code=code).first()
 
 
-
+def get_consortiums_by_code(current_session, codes):
+    return current_session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code.in_(codes)).all()
+    

--- a/amanuensis/utils.py
+++ b/amanuensis/utils.py
@@ -164,15 +164,17 @@ def getGQLFilterIdsList(ids_list):
 
     return { "AND": [{"IN":{"subject_submitter_id":ids_list}}]} 
 
-def get_consortium_list(path, src_filter, ids_list):
+def get_consortium_list(src_filter, ids_list, path=None):
     if src_filter is None and ids_list is None:
         raise NotFound("There is no filter specified and associated with the project you are trying to create")
+
+    if not path:
+        path = config["GET_CONSORTIUMS_URL"]
 
     isFilter = True if src_filter else False
     transformed_filter = src_filter if isFilter else getGQLFilterIdsList(ids_list)
     target_filter = {}
     target_filter["filter"] = transformed_filter
-
     try:
         url = path
         headers = {'Content-Type': 'application/json'}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1399,13 +1399,13 @@ testing = ["bson", "ecdsa", "feedparser", "gmpy2", "numpy", "pandas", "pymongo",
 
 [[package]]
 name = "mako"
-version = "1.3.3"
+version = "1.3.5"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Mako-1.3.3-py3-none-any.whl", hash = "sha256:5324b88089a8978bf76d1629774fcc2f1c07b82acdf00f4c5dd8ceadfffc4b40"},
-    {file = "Mako-1.3.3.tar.gz", hash = "sha256:e16c01d9ab9c11f7290eef1cfefc093fb5a45ee4a3da09e2fec2e4d1bae54e73"},
+    {file = "Mako-1.3.5-py3-none-any.whl", hash = "sha256:260f1dbc3a519453a9c856dedfe4beb4e50bd5a26d96386cb6c80856556bb91a"},
+    {file = "Mako-1.3.5.tar.gz", hash = "sha256:48dbc20568c1d276a2698b36d968fa76161bf127194907ea6fc594fa81f943bc"},
 ]
 
 [package.dependencies]

--- a/tests_endpoints/conftest.py
+++ b/tests_endpoints/conftest.py
@@ -38,6 +38,7 @@ def session(app_instance):
         session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST3").delete()
         session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "FAKE_CONSORTIUM_1").delete()
         session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "FAKE_CONSORTIUM_2").delete()
+        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "BAD").delete()
         session.query(State).filter(State.code == "STATE1").delete()
         session.query(State).filter(State.code == "STATE2").delete()
         session.query(AssociatedUserRoles).filter(AssociatedUserRoles.code == "TEST").delete()

--- a/tests_endpoints/conftest.py
+++ b/tests_endpoints/conftest.py
@@ -36,6 +36,8 @@ def session(app_instance):
         session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST1").delete()
         session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST2").delete()
         session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST3").delete()
+        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "FAKE_CONSORTIUM_1").delete()
+        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "FAKE_CONSORTIUM_2").delete()
         session.query(State).filter(State.code == "STATE1").delete()
         session.query(State).filter(State.code == "STATE2").delete()
         session.query(AssociatedUserRoles).filter(AssociatedUserRoles.code == "TEST").delete()

--- a/tests_endpoints/endpoints/conftest.py
+++ b/tests_endpoints/endpoints/conftest.py
@@ -1,22 +1,14 @@
 import pytest
-from mock import patch
+from mock import patch, Mock
 from cdislogging import get_logger
 
 
 logger = get_logger(logger_name=__name__)
 
-
-
 @pytest.fixture(scope='function')
 def patch_boto(app_instance):
     with patch.object(app_instance.boto, "presigned_url", return_value="aws_url_to_data"):
         yield
-
-# @pytest.fixture(scope="session", autouse=True)
-# def patch_get_jwt_from_header():
-#     # Mock the get_jwt_from_header function to always return "1.2.3"
-#     with patch('amanuensis.auth.auth.get_jwt_from_header', return_value='1.2.3'):
-#         yield
 
 @pytest.fixture(scope="session", autouse=True)
 def fence_users():
@@ -73,6 +65,16 @@ def fence_users():
             "last_auth": "Fri, 19 Jan 2024 20:33:37 GMT",
             "last_name": "endpoint_user_last_7",
             "name": "endpoint_user_7@test.com",
+            "role": "user"
+        }
+        ,
+        {
+            "first_name": "endpoint_user_8",
+            "id": 108,
+            "institution": "test university",
+            "last_auth": "Fri, 19 Jan 2024 20:33:37 GMT",
+            "last_name": "endpoint_user_last_8",
+            "name": "endpoint_user_8@test.com",
             "role": "user"
         }
     ]

--- a/tests_endpoints/endpoints/test_build_project.py
+++ b/tests_endpoints/endpoints/test_build_project.py
@@ -43,7 +43,7 @@ def test_2_create_project_with_one_request(app_instance, session, client, fence_
     with \
     patch("amanuensis.resources.admin.admin_associated_user.fence.fence_get_users", side_effect=fence_get_users_mock), \
     patch("amanuensis.blueprints.project.fence_get_users", side_effect=fence_get_users_mock), \
-    patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT", "INRG"]):
+    patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT", "INRG"]):
         with \
         patch('amanuensis.blueprints.filterset.current_user', id=101, username="endpoint_user_1@test.com"):
             
@@ -179,10 +179,6 @@ def test_2_create_project_with_one_request(app_instance, session, client, fence_
             """
             error_response  = client.post('/admin/projects', json={}, headers={"Authorization": 'bearer 200'})
             assert error_response.status_code == 400
-
-            with patch('amanuensis.resources.project.get_consortium_list', return_value=["bad"]):
-                error_response = client.post('/admin/projects', json=create_project_json, headers={"Authorization": 'bearer 200'})
-                assert error_response.status_code == 404
             
             """
             send a request to reterive all the possible roles

--- a/tests_endpoints/endpoints/test_cache_consortiums.py
+++ b/tests_endpoints/endpoints/test_cache_consortiums.py
@@ -1,0 +1,97 @@
+"""
+This file tests adding consortiums to the amanuensis DB when creating a project request or changing filter-set 
+when the consortiums returned from guppy are not in the amanuensis DB
+
+test 1: add a consortium when creating a data request
+
+test 2: add a consortium when changing a filter-set
+"""
+
+import pytest
+import json
+from mock import patch, Mock
+from cdislogging import get_logger
+from amanuensis.models import *
+from amanuensis.schema import *
+
+logger = get_logger(logger_name=__name__)
+
+
+
+
+
+@pytest.fixture(scope="module", autouse=True)
+def get_fake_consortium(session):
+    def get_consortium(consortium):
+         return session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == consortium).first()
+    
+    yield get_consortium
+
+@pytest.fixture(scope="module", autouse=True)
+def set_up_filter_set(client):
+    with \
+    patch('amanuensis.blueprints.filterset.current_user', id=108, username="endpoint_user_8@test.com"):
+        filter_set_create_1_json = {
+            "name":f"{__name__}",
+            "description":"",
+            "filters":{"__combineMode":"AND","__type":"STANDARD","value":{"consortium":{"__type":"OPTION","selectedValues":["FAKE_CONSORTIUM_1"],"isExclusion":False},"sex":{"__type":"OPTION","selectedValues":["Male"],"isExclusion":False}}},
+            "gqlFilter":{"AND":[{"IN":{"consortium":["FAKE_CONSORTIUM_1"]}},{"IN":{"sex":["Male"]}}]}
+        }
+        filter_set_create_response = client.post(f'/filter-sets?explorerId=1', json=filter_set_create_1_json, headers={"Authorization": 'bearer 108'})
+        assert filter_set_create_response.status_code == 200
+
+        filter_set_id_1 = filter_set_create_response.json["id"]
+
+        filter_set_create_2_json = {
+            "name":f"{__name__}",
+            "description":"",
+            "filters":{"__combineMode":"AND","__type":"STANDARD","value":{"consortium":{"__type":"OPTION","selectedValues":["FAKE_CONSORTIUM_2"],"isExclusion":False},"sex":{"__type":"OPTION","selectedValues":["Male"],"isExclusion":False}}},
+            "gqlFilter":{"AND":[{"IN":{"consortium":["FAKE_CONSORTIUM_2"]}},{"IN":{"sex":["Male"]}}]}
+        }
+        filter_set_create_response = client.post(f'/filter-sets?explorerId=1', json=filter_set_create_2_json, headers={"Authorization": 'bearer 108'})
+        assert filter_set_create_response.status_code == 200
+
+        filter_set_id_2 = filter_set_create_response.json["id"]
+
+        yield [filter_set_id_1, filter_set_id_2]
+
+
+def test_build_project_with_non_existent_consortium(set_up_filter_set, client, fence_get_users_mock, get_fake_consortium):
+    with \
+    patch("amanuensis.resources.admin.admin_associated_user.fence.fence_get_users", side_effect=fence_get_users_mock), \
+    patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
+    patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["FAKE_CONSORTIUM_1"]):
+        from amanuensis import config
+        create_project_json = {
+            "user_id": 108,
+            "name": f"{__name__}",
+            "description": f"this is the project for {__name__}",
+            "institution": "test university",
+            "filter_set_ids": [set_up_filter_set[0]],
+            "associated_users_emails": []
+
+        }
+        create_project_response = client.post('/admin/projects', json=create_project_json, headers={"Authorization": 'bearer 200'})
+        
+        assert create_project_response.status_code == 200
+        
+        assert get_fake_consortium("FAKE_CONSORTIUM_1")
+
+def test_change_filter_set_with_non_existent_consortium(set_up_filter_set, client, get_fake_consortium, session):
+     
+    project_id = session.query(Project).filter(Project.name == f"{__name__}").first().id
+
+    filter_set_id = set_up_filter_set[1]
+
+    copy_search_to_project_json = {
+        "filtersetId": filter_set_id,
+        "projectId": project_id
+    }
+    with \
+    patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
+    patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["FAKE_CONSORTIUM_2"]):
+        
+        copy_search_to_project_response = client.post("admin/copy-search-to-project", json=copy_search_to_project_json, headers={"Authorization": 'bearer 200'})
+        assert copy_search_to_project_response.status_code == 200
+
+        assert get_fake_consortium("FAKE_CONSORTIUM_2")

--- a/tests_endpoints/endpoints/test_change_requests_with_new_filter_set.py
+++ b/tests_endpoints/endpoints/test_change_requests_with_new_filter_set.py
@@ -51,7 +51,7 @@ def test_change_requests_with_new_filter_set(app_instance, session, client, fenc
 
         with \
         patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
-        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT"]):
+        patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT"]):
             create_project_json = {
                 "user_id": 106,
                 "name": f"{__name__}",
@@ -92,7 +92,7 @@ def test_change_requests_with_new_filter_set(app_instance, session, client, fenc
 
         with \
         patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
-        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT", "INRG", "INTERACT"]):
+        patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT", "INRG", "INTERACT"]):
             admin_copy_search_to_project_json = {
                 "filtersetId": id_3_requests,
                 "projectId": project_id
@@ -135,7 +135,7 @@ def test_change_requests_with_new_filter_set(app_instance, session, client, fenc
 
         with \
         patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
-        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT"]):
+        patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT"]):
             admin_copy_search_to_project_json = {
                 "filtersetId": id_1_requests,
                 "projectId": project_id
@@ -184,7 +184,7 @@ def test_change_requests_with_new_filter_set(app_instance, session, client, fenc
 
         with \
         patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
-        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT", "INRG"]):
+        patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT", "INRG"]):
             admin_copy_search_to_project_json = {
                 "filtersetId": id_3_requests,
                 "projectId": project_id

--- a/tests_endpoints/endpoints/test_get_presigned_url.py
+++ b/tests_endpoints/endpoints/test_get_presigned_url.py
@@ -78,7 +78,7 @@ def set_up_project(client, fence_get_users_mock):
 
         with \
         patch('amanuensis.blueprints.admin.current_user', id=200, username="admin@uchicago.edu"), \
-        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT"]):
+        patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT"]):
             create_project_json = {
                 "user_id": 107,
                 "name": f"{__name__}",

--- a/tests_endpoints/endpoints/test_patch_125.py
+++ b/tests_endpoints/endpoints/test_patch_125.py
@@ -25,7 +25,7 @@ def test_admin_creates_project_with_filter_set_project_owner_dont_match(session,
         filter_set_id = filter_set_create_response.json["id"]
 
         with \
-        patch('amanuensis.resources.project.get_consortium_list', return_value=["INSTRuCT"]):
+        patch('amanuensis.resources.consortium_data_contributor.get_consortium_list', return_value=["INSTRuCT"]):
             create_project_json = {
                 "user_id": 106,
                 "name": f"{__name__}",


### PR DESCRIPTION
1) when creating a request or changing a filter-set if a consortium returned from pcdcanalysistools is not present in the amanuensis DB it will be added. 

2) there was a not about adding the pcdcanalysistools route into the config so I did that. I can change it back if that should not be included but now the route is dynamic instead of hardcoded

3) rearranged duplicate code in the project create and filter-set change method, removed duplicate calls to the DB and removed error checks that are no longer relevant 