### PR TITLE
Peds 1293

### DIFF
--- a/amanuensis/blueprints/download_urls.py
+++ b/amanuensis/blueprints/download_urls.py
@@ -61,6 +61,7 @@ def download_data(project_id):
         #check if project is in fianl state or in Data Download state before attempting to change state
         change_request_state(session, project_id, state_code="DATA_DOWNLOADED")
             
+        session.commit()
 
         # Create pre-signed URL for downalod
         s3_info = get_s3_key_and_bucket(storage_url)

--- a/amanuensis/blueprints/filterset.py
+++ b/amanuensis/blueprints/filterset.py
@@ -71,6 +71,7 @@ def create_search():
             graphql_object=graphql_object
         )
         search_schema = SearchSchema()
+        session.commit()
         return search_schema.dump(new_filter_set)
 
 
@@ -117,6 +118,8 @@ def update_search(filter_set_id):
                                     graphql_object=graphql_object,
                                     delete= True if flask.request.method == "DELETE" else False
                                 )
+        
+        session.commit()
     
         return search_schema.dump(updated_filter_set)
 
@@ -141,6 +144,8 @@ def create_snapshot_from_filter_set():
     
     with flask.current_app.db.session as session:
         snapshot = create_filter_set_snapshot(session, logged_user_id, filter_set_id, users_list)
+
+        session.commit()
 
         return flask.jsonify(snapshot)
 

--- a/amanuensis/resources/consortium_data_contributor/__init__.py
+++ b/amanuensis/resources/consortium_data_contributor/__init__.py
@@ -3,7 +3,7 @@ from amanuensis.resources.userdatamodel.consortium_data_contributor import creat
 from amanuensis.auth.auth import get_jwt_from_header
 import json
 import requests
-from amanuensis.errors import NotFound
+from amanuensis.errors import NotFound, InternalError
 from amanuensis.config import config
 
 logger = get_logger(__name__)
@@ -29,10 +29,15 @@ def get_consortium_list(src_filter, ids_list, path=None):
         r = requests.post(
             url, data=body, headers=headers # , proxies=flask.current_app.config.get("EXTERNAL_PROXIES")
         )
-    except requests.HTTPError as e:
+    except requests.RequestException as e:
         print(e.message)
+       
 
-    return r.json()
+    if r.status_code != 200:
+        raise InternalError(f"Sorry could not complete request")
+
+    else:
+        return r.json()
 
 
 def get_consortiums_from_fitersets(filter_sets, session):

--- a/amanuensis/resources/request/__init__.py
+++ b/amanuensis/resources/request/__init__.py
@@ -98,7 +98,7 @@ def project_requests_from_filter_sets(session, filter_set_ids=None, project_id=N
 
     project.searches = filter_sets
 
-    session.commit()
+    session.flush()
     project_schema.dump(project)
     return project
     

--- a/amanuensis/resources/userdatamodel/associated_users.py
+++ b/amanuensis/resources/userdatamodel/associated_users.py
@@ -95,7 +95,7 @@ def update_associated_user(current_session,
     user.email = new_email if new_email else user.email
     user.active = True if not delete else False
 
-    current_session.commit()
+    current_session.flush()
 
     return user
 
@@ -129,6 +129,6 @@ def create_associated_user(current_session, email, user_id=None, user_source="fe
 
         logger.info(f"User {new_user} has been created")
     
-    current_session.commit()
+    current_session.flush()
     
     return user if user else new_user

--- a/amanuensis/resources/userdatamodel/consortium_data_contributor.py
+++ b/amanuensis/resources/userdatamodel/consortium_data_contributor.py
@@ -64,7 +64,7 @@ def create_consortium(current_session, name, code):
             consortium
         )
 
-    current_session.commit()
+    current_session.flush()
 
     return consortium
 

--- a/amanuensis/resources/userdatamodel/message.py
+++ b/amanuensis/resources/userdatamodel/message.py
@@ -44,7 +44,7 @@ def send_message(
     else:
         if receivers:
             current_session.add(new_message)
-            current_session.commit()
+            current_session.flush()
 
     if is_env_enabled("AWS_SES_DEBUG"):
         logger.debug(f"send_message emails (debug mode): {str(emails)}")

--- a/amanuensis/resources/userdatamodel/project.py
+++ b/amanuensis/resources/userdatamodel/project.py
@@ -97,7 +97,7 @@ def create_project(current_session, user_id, description, name, institution):
 
     current_session.add(new_project)
 
-    current_session.commit()
+    current_session.flush()
 
     return new_project
 
@@ -127,6 +127,6 @@ def update_project(current_session,
     project.approved_url = approved_url if approved_url is not None else project.approved_url
     project.active = True if not delete else False
 
-    current_session.commit()
+    current_session.flush()
 
     return project

--- a/amanuensis/resources/userdatamodel/project_has_associated_user.py
+++ b/amanuensis/resources/userdatamodel/project_has_associated_user.py
@@ -90,7 +90,7 @@ def update_project_associated_user(
     project_associated_user.active = True if not delete else False
     project_associated_user.role_id = role_id if role_id else project_associated_user.role_id
 
-    current_session.commit()
+    current_session.flush()
 
     return project_associated_user
 
@@ -128,7 +128,7 @@ def create_project_associated_user(
 
         current_session.add(new_project_associated_user)
     
-    current_session.commit()
+    current_session.flush()
     
     return project_associated_user
     

--- a/amanuensis/resources/userdatamodel/project_has_search.py
+++ b/amanuensis/resources/userdatamodel/project_has_search.py
@@ -42,6 +42,6 @@ def create_project_search(current_session, project_id, filter_set_id):
     else:
         project_search = ProjectSearch(project_id=project_id, filter_set_id=filter_set_id)
         current_session.add(project_search)
-        current_session.commit()
+        current_session.flush()
         
     return project_search

--- a/amanuensis/resources/userdatamodel/request.py
+++ b/amanuensis/resources/userdatamodel/request.py
@@ -63,6 +63,6 @@ def create_request(current_session, project_id, consortium_id):
     current_session.add(request)
 
 
-    current_session.commit()
+    current_session.flush()
 
     return request

--- a/amanuensis/resources/userdatamodel/request_has_state.py
+++ b/amanuensis/resources/userdatamodel/request_has_state.py
@@ -101,6 +101,6 @@ def create_request_state(current_session, request_id, state_id):
     else:
         request_state = RequestState(request_id=request_id, state_id=state_id)
         current_session.add(request_state)
-        current_session.commit()
+        current_session.flush()
 
     return request_state

--- a/amanuensis/resources/userdatamodel/search.py
+++ b/amanuensis/resources/userdatamodel/search.py
@@ -95,7 +95,7 @@ def create_filter_set(
     )
     # TODO add es_index, add dataset_version
     current_session.add(new_filter_set)
-    current_session.commit()
+    current_session.flush()
 
     return new_filter_set
 
@@ -121,7 +121,7 @@ def update_filter_set(
     filter_set.graphql_object = graphql_object if graphql_object is not None else filter_set.graphql_object
     filter_set.active = True if not delete else False
 
-    current_session.commit()
+    current_session.flush()
 
     return filter_set
 

--- a/amanuensis/resources/userdatamodel/search_is_shared.py
+++ b/amanuensis/resources/userdatamodel/search_is_shared.py
@@ -66,6 +66,6 @@ def create_filter_set_snapshot(current_session,
 
     # filter_set.snapshots.append(shared_search)
     current_session.add(shared_search)
-    current_session.commit()
+    current_session.flush()
     
     return shareable_token

--- a/amanuensis/resources/userdatamodel/state.py
+++ b/amanuensis/resources/userdatamodel/state.py
@@ -63,6 +63,6 @@ def create_state(current_session, name, code):
             state
         )
 
-        current_session.commit()
+        current_session.flush()
 
     return state

--- a/poetry.lock
+++ b/poetry.lock
@@ -2200,23 +2200,23 @@ crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "setuptools"
-version = "75.2.0"
+version = "75.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
-    {file = "setuptools-75.2.0.tar.gz", hash = "sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"},
+    {file = "setuptools-75.3.0-py3-none-any.whl", hash = "sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd"},
+    {file = "setuptools-75.3.0.tar.gz", hash = "sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686"},
 ]
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.5.2)"]
-core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.11.*)", "pytest-mypy"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test (>=5.5)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12.*)", "pytest-mypy"]
 
 [[package]]
 name = "six"
@@ -2378,13 +2378,13 @@ resolved_reference = "a4b76f7b4e2c70b732dc1224529a512d8fb97e23"
 
 [[package]]
 name = "werkzeug"
-version = "3.0.5"
+version = "3.0.6"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "werkzeug-3.0.5-py3-none-any.whl", hash = "sha256:6e589e0b303561b8b1a61d363ee05b1d7de6ca12f27a3a25269ae6ee93e363fd"},
-    {file = "werkzeug-3.0.5.tar.gz", hash = "sha256:033bc3783777078517f32ae3ba9e86e9bc38bdbf139b1a5a3af9679a64ed1293"},
+    {file = "werkzeug-3.0.6-py3-none-any.whl", hash = "sha256:1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17"},
+    {file = "werkzeug-3.0.6.tar.gz", hash = "sha256:a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d"},
 ]
 
 [package.dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,7 @@ from amanuensis.errors import AuthError
 app_init(app, config_file_name="amanuensis-config.yaml")
 
 logger = get_logger(logger_name=__name__)
-
-
+from amanuensis.models import ConsortiumDataContributor
 
 @pytest.fixture(scope="session")
 def app_instance():
@@ -38,15 +37,28 @@ def session(app_instance):
         session.query(AssociatedUser).delete()
         session.query(Request).delete()
         session.query(Project).delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "ENDPOINT_TEST").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST1").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST2").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "TEST3").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "FAKE_CONSORTIUM_1").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "FAKE_CONSORTIUM_2").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "BAD").delete()
-        session.query(ConsortiumDataContributor).filter(ConsortiumDataContributor.code == "NOT_IN_DB").delete()
+        session.query(ConsortiumDataContributor).delete()
+        consortiums = []
+        consortiums.append(
+            ConsortiumDataContributor(
+                name="INRG", 
+                code ="INRG"
+            )
+        )
+        consortiums.append(
+                ConsortiumDataContributor(
+                    name="INSTRUCT", 
+                    code ="INSTRUCT"
+                    )
+        )
+        consortiums.append(
+            ConsortiumDataContributor(
+                name="INTERACT",
+                code ="INTERACT"
+            )
+        )
+
+        session.add_all(consortiums)
         session.query(State).filter(State.code == "STATE1").delete()
         session.query(State).filter(State.code == "STATE2").delete()
         session.query(State).filter(State.code == "ENDPOINT_TEST").delete()
@@ -56,6 +68,8 @@ def session(app_instance):
         session.commit()
 
         yield session
+
+        session.commit()
     
 
 @pytest.fixture(scope='function')
@@ -142,11 +156,13 @@ def patch_auth_request(app_instance, find_fence_user):
 def mock_requests_post(request, find_fence_user):
 
 
-    def do_patch(consortiums=None):
+    def do_patch(consortiums=None, urls={}):
         
         def response_for(url, *args, **kwargs):
-
-            urls = [config["GET_CONSORTIUMS_URL"], "http://fence-service/admin/users/selected"]
+            nonlocal urls
+            default_urls = {config["GET_CONSORTIUMS_URL"]: 200, "http://fence-service/admin/users/selected": 200}
+            default_urls.update(urls)
+            urls = default_urls
 
             mocked_response = MagicMock(requests.post)
 
@@ -154,9 +170,14 @@ def mock_requests_post(request, find_fence_user):
                 mocked_response.status_code = 404
                 mocked_response.text = "NOT FOUND"
 
-            elif 'data' not in kwargs:
+            elif 'data' not in kwargs or urls[url] == 400:
                 mocked_response.status_code = 400
-                mocked_response.text = "BAD REQUEST"
+                mocked_response.json = MagicMock(return_value="BAD REQUEST")
+            
+            elif urls[url] == 403:
+                mocked_response.status_code = 403
+                mocked_response.text = "FORBIDDEN"
+
             
             else:
                 if isinstance(kwargs["data"], str):

--- a/tests/test_associated_user_roles.py
+++ b/tests/test_associated_user_roles.py
@@ -13,23 +13,19 @@ def test_get_assoicated_user_role_many(session):
 
     assert len(role) == 2
 
-
 def test_get_associated_user_role_by_id(session):
     # Assuming the session contains a role with id 1
     role = get_associated_user_roles(session, id=1, many=False)
     assert role.id == 1
     assert role.role == "DATA_ACCESS"  # Assuming id=1 corresponds to "admin"
 
-
 def test_no_roles_found_raises_error(session):
     with pytest.raises(NotFound):
         get_associated_user_roles(session, id=999, throw_not_found=True)
 
-
 def test_no_roles_found_returns_empty_list(session):
     roles = get_associated_user_roles(session, id=999, throw_not_found=False)
     assert roles == []  # Expecting an empty list when no roles are found
-
 
 def test_user_error(session):
     with pytest.raises(UserError):

--- a/tests/test_request_has_state.py
+++ b/tests/test_request_has_state.py
@@ -5,6 +5,7 @@ from amanuensis.resources.userdatamodel.project import create_project
 from amanuensis.resources.userdatamodel.consortium_data_contributor import get_consortiums
 from amanuensis.resources.userdatamodel.associated_users import create_associated_user
 import pytest
+from time import sleep
 
 @pytest.fixture(scope="session", autouse=True)
 def create_test_data(session, register_user):
@@ -28,11 +29,12 @@ def test_create_request_state(session, create_test_data):
     assert create_request_state(session, request_1.id, IN_REVIEW.id)
     assert create_request_state(session, request_2.id, IN_REVIEW.id)
     assert create_request_state(session, request_3.id, IN_REVIEW.id)
+    session.commit()
 
     APPROVED = get_states(session, code="APPROVED", many=False)
 
     assert create_request_state(session, request_1.id, APPROVED.id)
-
+    session.commit()
     #block create duplicate
     assert create_request_state(session, request_1.id, APPROVED.id)
     assert len(get_request_states(session, request_id=request_1.id)) == 2
@@ -45,6 +47,7 @@ def test_create_request_state(session, create_test_data):
 
     assert create_request_state(session, request_1.id, DEPRECATED.id)
 
+    session.commit()
 
 @pytest.mark.order(2)
 def test_get_request_state(session, create_test_data):
@@ -65,3 +68,5 @@ def test_get_request_state(session, create_test_data):
     assert len(get_request_states(session, request_id=request_2.id, latest=True, filter_out_depricated=True)) == 1
 
     assert len(get_request_states(session, request_id=[request_1.id, request_2.id, request_3.id], state_id=IN_REVIEW.id)) == 3
+
+    session.commit()


### PR DESCRIPTION
blocks project creation if request sent to pcdcanalysistools is not 200. Also for consistency all DB operations methods will move to session.flush() and all sessions will commit changes at the end of the endpoint with session.commit(). This will prevent data being added to DB until the whole of operation is completed, example dont create row in project table if attempting to add the filter-set fails. This also should reduce the response time for requests. 