### PR TITLE
update boto handling

### DIFF
--- a/amanuensis/__init__.py
+++ b/amanuensis/__init__.py
@@ -132,13 +132,21 @@ def app_config(
 
 
 def _setup_data_endpoint_and_boto(app):
-    if "AWS_CREDENTIALS" in config and len(config["AWS_CREDENTIALS"]) > 0:
-        #TODO why does it need to be the first one? (use the key value in the object instead of making it a list)
-        value = list(config["AWS_CREDENTIALS"].values())[0]
-        app.boto = BotoManager(value, logger=logger)
-        logger.info("BotoManager initialized")
-    else:
-        logger.warning("Missing credentials for BotoManager, delivery of data will fail.")
+    try:
+        app.s3_boto = BotoManager(
+            config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"], logger=logger
+        )
+    except Exception as e:
+        logger.error(f"Could not initialize data delivery BotoManager.")
+        app.s3_boto = None
+    
+    try:
+        app.ses_boto = BotoManager(
+            config["AWS_CREDENTIALS"]["SES"], logger=logger
+        )
+    except Exception as e:
+        logger.error(f"Could not initialize SES BotoManager.")
+        app.ses_boto = None
 
 def _setup_arborist_client(app):
     if app.config.get("ARBORIST"):

--- a/amanuensis/__init__.py
+++ b/amanuensis/__init__.py
@@ -19,6 +19,7 @@ import amanuensis.blueprints.project
 import amanuensis.blueprints.admin
 import amanuensis.blueprints.download_urls
 import amanuensis.blueprints.notification
+from copy import deepcopy
 
 
 # Can't read config yet. Just set to debug for now, else no handlers.
@@ -133,7 +134,7 @@ def app_config(
 
 def _setup_data_endpoint_and_boto(app):
     try:
-        aws_creds = config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"]
+        aws_creds = deepcopy(config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"])
         del aws_creds["bucket_name"]
         app.s3_boto = BotoManager(
             aws_creds, logger=logger

--- a/amanuensis/__init__.py
+++ b/amanuensis/__init__.py
@@ -133,8 +133,10 @@ def app_config(
 
 def _setup_data_endpoint_and_boto(app):
     try:
+        aws_creds = config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"]
+        del aws_creds["bucket_name"]
         app.s3_boto = BotoManager(
-            config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"], logger=logger
+            aws_creds, logger=logger
         )
     except Exception as e:
         logger.error(f"Could not initialize data delivery BotoManager.")

--- a/amanuensis/blueprints/download_urls.py
+++ b/amanuensis/blueprints/download_urls.py
@@ -32,7 +32,7 @@ def download_data(project_id):
             "Unable to load or find the user, check your token"
         )
 
-    if not flask.current_app.boto:
+    if not flask.current_app.s3_boto:
         raise InternalError("BotoManager not found. Check the AWS credentials are set in the config and have the correct permissions.")
 
     # Check param is present
@@ -68,7 +68,7 @@ def download_data(project_id):
         if s3_info is None:
             raise NotFound("The S3 bucket and key information cannot be extracted from the URL {}".format(storage_url))
 
-        result = flask.current_app.boto.presigned_url(s3_info["bucket"], s3_info["key"], "1800", {}, "get_object")
+        result = flask.current_app.s3_boto.presigned_url(s3_info["bucket"], s3_info["key"], "1800", {}, "get_object")
         return flask.jsonify({"download_url": result})
 
 

--- a/amanuensis/config-default.yaml
+++ b/amanuensis/config-default.yaml
@@ -150,7 +150,13 @@ SUPPORT_EMAIL_FOR_ERRORS: null
 #   - Support `/data` endpoints
 # //////////////////////////////////////////////////////////////////////////////////////
 AWS_CREDENTIALS:
-  'DATA_DELIVERY_S3_BUCKET':
+  AWS_SES:
+    SENDER: ""
+    RECIPIENT: ""
+    AWS_REGION: "us-east-1"
+    aws_access_key_id: ""
+    aws_secret_access_key: ""
+  DATA_DELIVERY_S3_BUCKET:
     aws_access_key_id: 'DATA_DELIVERY_S3_BUCKET_ACCESS_KEY'
     aws_secret_access_key: 'DATA_DELIVERY_S3_BUCKET_PRIVATE_KEY'
 # NOTE: Remove the {} and supply creds if needed. Example in comments below
@@ -220,12 +226,7 @@ FENCE: 'http://fence-service'
 # Simple Email Service (for sending emails from fence)
 #
 # NOTE: Example in comments below
-AWS_SES:
-  SENDER: ""
-  RECIPIENT: ""
-  AWS_REGION: "us-east-1"
-  AWS_ACCESS_KEY: ""
-  AWS_SECRET_KEY: ""
+
 
 HUBSPOT:
   API_KEY: "DEV_KEY"

--- a/amanuensis/config-default.yaml
+++ b/amanuensis/config-default.yaml
@@ -157,6 +157,7 @@ AWS_CREDENTIALS:
     aws_access_key_id: ""
     aws_secret_access_key: ""
   DATA_DELIVERY_S3_BUCKET:
+    bucket_name: ""
     aws_access_key_id: 'DATA_DELIVERY_S3_BUCKET_ACCESS_KEY'
     aws_secret_access_key: 'DATA_DELIVERY_S3_BUCKET_PRIVATE_KEY'
 # NOTE: Remove the {} and supply creds if needed. Example in comments below

--- a/amanuensis/resources/message/__init__.py
+++ b/amanuensis/resources/message/__init__.py
@@ -123,8 +123,8 @@ def send_admin_message(project, consortiums, subject, body):
             logger.debug(f"send_message emails (debug mode): {str(requesters)}")
         elif receivers:
             # Send the Message via AWS SES
-            flask.current_app.boto.send_email_ses(body, receivers, subject)
-            flask.current_app.boto.send_email_ses(body, requesters, subject)
+            flask.current_app.ses_boto.send_email_ses(body, receivers, subject)
+            flask.current_app.ses_boto.send_email_ses(body, requesters, subject)
 
 
 def notify_user_project_status_update(current_session, project_id, consortiums):

--- a/amanuensis/resources/project/__init__.py
+++ b/amanuensis/resources/project/__init__.py
@@ -45,13 +45,13 @@ def create(current_session, logged_user_id, is_amanuensis_admin, name, descripti
 def upload_file(session, key, project_id, expires=None):
 
     try:
-        presigned_url = flask.current_app.s3_boto.presigned_url(config["DATA_DOWNLOAD_BUCKET"], key, expires, {}, method="put_object")
+        presigned_url = flask.current_app.s3_boto.presigned_url(config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"]["bucket_name"], key, expires, {}, method="put_object")
 
     except Exception as e:
         logger.error(f"Failed to generate presigned url: {e}")
         raise InternalError("Failed to generate presigned url")
     
-    update_project(session, project_id, approved_url=f"https://{config['DATA_DOWNLOAD_BUCKET']}.s3.amazonaws.com/{key}")
+    update_project(session, project_id, approved_url=f'https://{config["AWS_CREDENTIALS"]["DATA_DELIVERY_S3_BUCKET"]["bucket_name"]}.s3.amazonaws.com/{key}')
 
     return presigned_url
 

--- a/amanuensis/resources/project/__init__.py
+++ b/amanuensis/resources/project/__init__.py
@@ -44,16 +44,14 @@ def create(current_session, logged_user_id, is_amanuensis_admin, name, descripti
 
 def upload_file(session, key, project_id, expires=None):
 
-    bucket = list(config['AWS_CREDENTIALS'].keys())[0]
-
     try:
-        presigned_url = flask.current_app.boto.presigned_url(bucket, key, expires, bucket, method="put_object")
+        presigned_url = flask.current_app.s3_boto.presigned_url(config["DATA_DOWNLOAD_BUCKET"], key, expires, {}, method="put_object")
 
     except Exception as e:
         logger.error(f"Failed to generate presigned url: {e}")
         raise InternalError("Failed to generate presigned url")
     
-    update_project(session, project_id, approved_url=f"https://{bucket}.s3.amazonaws.com/{key}")
+    update_project(session, project_id, approved_url=f"https://{config['DATA_DOWNLOAD_BUCKET']}.s3.amazonaws.com/{key}")
 
     return presigned_url
 

--- a/amanuensis/resources/userdatamodel/message.py
+++ b/amanuensis/resources/userdatamodel/message.py
@@ -50,6 +50,6 @@ def send_message(
         logger.debug(f"send_message emails (debug mode): {str(emails)}")
     elif emails:
         # Send the Message via AWS SES
-        return current_app.boto.send_email_ses(body, emails, subject)
+        return current_app.ses_boto.send_email_ses(body, emails, subject)
 
     return new_message

--- a/amanuensis/utils.py
+++ b/amanuensis/utils.py
@@ -279,7 +279,7 @@ def send_email_ses(body, to_emails, subject):
         #     self._format = 'text'
         #     body = self._text
 
-    flask.current_app.boto.send_email(sender, to_emails, subject, body, body_text, 'UTF-8', config)
+    flask.current_app.ses_boto.send_email(sender, to_emails, subject, body, body_text, 'UTF-8', config)
     # logging.debug(json.dumps(response))
     # return response
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,9 +259,12 @@ def login(request, find_fence_user):
 
 @pytest.fixture(scope="module", autouse=True)
 def s3(app_instance):
+
+    s3 = None
+
     try: 
 
-        s3 = app_instance.boto.s3_client
+        s3 = app_instance.s3_boto.s3_client
         bucket_name = 'amanuensis-upload-file-test-bucket'
 
         # Check if the bucket exists
@@ -287,18 +290,17 @@ def s3(app_instance):
     
     except Exception as e:
         logger.error(f"Failed to set up s3 bucket, tests will fail {e}")
-        yield None
 
     yield s3
-
-    response = s3.list_objects_v2(Bucket=bucket_name)
-    if 'Contents' in response:
-        for obj in response['Contents']:
-            s3.delete_object(Bucket=bucket_name, Key=obj['Key'])
-            logger.info(f"deleted {obj['Key']}")
-    
-    s3.delete_bucket(Bucket=bucket_name)
-    logger.info(f"delete bucket {bucket_name}")
+    if s3:
+        response = s3.list_objects_v2(Bucket=bucket_name)
+        if 'Contents' in response:
+            for obj in response['Contents']:
+                s3.delete_object(Bucket=bucket_name, Key=obj['Key'])
+                logger.info(f"deleted {obj['Key']}")
+        
+        s3.delete_bucket(Bucket=bucket_name)
+        logger.info(f"delete bucket {bucket_name}")
 
 # Add a finalizer to ensure proper teardown
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_build_project.py
+++ b/tests/test_build_project.py
@@ -807,6 +807,7 @@ def test_get_projects(session, client, login, project_data, mock_requests_post):
 
     login(project_data["user_2_id"], project_data["user_2_email"])
     user_2_get_projects_response = client.get("/projects", headers={"Authorization": f'bearer {project_data["user_2_id"]}'})
+    print(user_2_get_projects_response.json)
     assert len(user_2_get_projects_response.json) == 1
 
 


### PR DESCRIPTION
This is the amanuensis side of peds 1309 which allows for two different sets of aws creds and creates two boto managers. It also removes the part where the key for the credentials is the name of the bucket and now the name of the bucket is the value for the key DATA_DOWNLOAD_BUCKET