### PR TITLE
PEDS-1385 PEDS-1367

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.testing.pytestArgs": [
+        "tests",
+        "--order-scope=module",
+        "--disable-warnings",
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/amanuensis/blueprints/admin.py
+++ b/amanuensis/blueprints/admin.py
@@ -23,7 +23,7 @@ from amanuensis.resources.request import change_request_state, project_requests_
 from amanuensis.resources.userdatamodel.associated_user_roles import get_associated_user_roles
 from amanuensis.resources.userdatamodel.project_has_associated_user import get_project_associated_users, update_project_associated_user
 from amanuensis.resources.userdatamodel.associated_users import get_associated_users
-from amanuensis.resources.associated_user import add_associated_users
+from amanuensis.resources.associated_user import add_associated_users, remove_associated_user
 from amanuensis.resources.userdatamodel.project import get_projects
 from amanuensis.resources.userdatamodel.notification import get_notifications, update_notification
 from amanuensis.resources.userdatamodel.notification_log import create_notification_log, update_notification_log, get_notification_logs
@@ -452,16 +452,10 @@ def delete_user_from_project():
         raise UserError("A project is nessary for this endpoint")
 
     with current_app.db.session as session:
+
+        project_user = remove_associated_user(session, project_id, user_id=associated_user_id, email=associated_user_email)
         project_associated_user_schema = ProjectAssociatedUserSchema()
-        project = get_projects(session, id=project_id, many=False, throw_not_found=True)
-        if project.user_id == associated_user_id:
-            raise UserError("You can't remove the owner from the project")
-        user = get_associated_users(session, email=associated_user_email, user_id=associated_user_id,  many=False, throw_not_found=True)
-
-        project_user = update_project_associated_user(session, project_id=project_id, associated_user_id=user.id, delete=True)
-
         session.commit()
-
         return project_associated_user_schema.dump(project_user)
 
 

--- a/amanuensis/blueprints/project.py
+++ b/amanuensis/blueprints/project.py
@@ -114,6 +114,8 @@ def get_projetcs():
             tmp_project["consortia"] = list(consortiums)
             return_projects.append(tmp_project)
 
+        session.commit()
+
     return flask.jsonify(return_projects)
 
 

--- a/amanuensis/resources/associated_user/__init__.py
+++ b/amanuensis/resources/associated_user/__init__.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
-from amanuensis.errors import  UserError
-from amanuensis.schema import ProjectAssociatedUserSchema
+from amanuensis.errors import  UserError, NotFound
 from amanuensis.resources.fence import fence_get_users
-from amanuensis.resources.userdatamodel.associated_users import update_associated_user, create_associated_user
+from amanuensis.resources.userdatamodel.associated_users import update_associated_user, create_associated_user, get_associated_users
 from amanuensis.resources.userdatamodel.associated_user_roles import get_associated_user_roles
-from amanuensis.resources.userdatamodel.project_has_associated_user import create_project_associated_user
+from amanuensis.resources.userdatamodel.project_has_associated_user import create_project_associated_user, update_project_associated_user, get_project_associated_users
+from amanuensis.resources.userdatamodel.project import get_projects
 from amanuensis.config import config
 from cdislogging import get_logger
 
@@ -13,6 +13,7 @@ logger = get_logger(__name__)
 
 __all__ = [
     "add_associated_users",
+    "remove_associated_user"
 ]
 
 
@@ -23,44 +24,82 @@ def add_associated_users(session, users, role=None):
     input_users = [defaultdict(lambda: None, user) for user in users]
     for input_user in input_users:
 
-    
+        email = input_user["email"] if "email" in input_user else None
+        id = input_user["id"] if "id" in input_user else None
         
         if "project_id" not in input_user:
             raise UserError("The project_id is required to add user to project")
+        
+        get_projects(session, id=input_user["project_id"], throw_not_found=True, many=False)
 
-        if "email" in input_user:
-            fence_user = fence_get_users(usernames=[input_user["email"]])["users"]
+        if email:
+            fence_user = fence_get_users(usernames=[email])["users"]
 
             if fence_user:
-                if input_user["id"] and input_user["id"] != fence_user[0]["id"]:
-                    raise UserError(f"The user id {input_user['id']} does not exist in the commons")
+                if id and id != fence_user[0]["id"]:
+                    raise UserError(f"The user id {id} does not exist in the commons")
                 else:
-                    input_user["id"] = fence_user[0]["id"]
+                    id = fence_user[0]["id"]
+            
+            elif id:
+                raise UserError(f"The user id {id} does not match the email {email} in the commons")
 
             else:
-                logger.info("The user {} has not created an account in the commons yet".format(input_user["id"] if "id" in input_user else input_user["email"]))
+                logger.info("The user {} has not created an account in the commons yet".format(email))
                 #TODO send message via aws to the email address inviting them to sign up          
         
-        elif "id" in input_user:
-            fence_user = fence_get_users(ids=[input_user["id"]])["users"]
+        elif id:
+            fence_user = fence_get_users(ids=[id])["users"]
 
             if fence_user:
-                input_user["email"] = fence_user[0]["name"]
+                email = fence_user[0]["name"]
 
             else:
-                raise UserError(f"The user id {input_user['id']} does not exist in the commons")
+                raise UserError(f"The user id {id} does not exist in the commons")
 
         else:
             raise UserError("The user id or email is required")
         
 
-        associated_user = create_associated_user(session, email=input_user["email"], user_id=input_user["id"])
+        associated_user = create_associated_user(session, email=email, user_id=id)
 
-        if not associated_user.user_id and input_user["id"]:
-            update_associated_user(session, user=associated_user, new_user_id=input_user["id"])
+        if not associated_user.user_id and id:
+            update_associated_user(session, user=associated_user, new_user_id=id)
 
         project_associated_user = create_project_associated_user(session, project_id=input_user["project_id"], associated_user_id=associated_user.id, role_id=ROLE.id)
 
         ret.append(project_associated_user)
 
     return ret
+
+
+def remove_associated_user(session, project_id, user_id=None, email=None):
+    project = get_projects(session, id=project_id, many=False, throw_not_found=True)
+   
+    
+    
+    if email:
+        project_user = get_project_associated_users(session, project_id=project_id, associated_user_email=email, many=False, throw_not_found=True)
+
+    else:
+        project_user = get_project_associated_users(session, project_id=project_id, associated_user_user_id=user_id, many=False)
+
+        #this covers a situation if a user signs up but never goes to data request page
+        if not project_user:
+            try:
+                fence_user_email = fence_get_users(ids=[user_id])["users"][0]["name"]
+            except Exception as e:
+                raise NotFound(f"User {user_id} not found in commons")
+            
+            project_user = get_project_associated_users(session, project_id=project_id, associated_user_email=fence_user_email, many=False, throw_not_found=True)
+            update_associated_user(session, old_email=fence_user_email, new_user_id=user_id)
+    
+    if project.user_id == project_user.associated_user.user_id:
+        raise UserError("You can't remove the owner from the project")
+    
+
+    
+    updated_project_user = update_project_associated_user(session, project_associated_user=project_user, delete=True)
+
+
+    return updated_project_user

--- a/amanuensis/resources/associated_user/__init__.py
+++ b/amanuensis/resources/associated_user/__init__.py
@@ -37,7 +37,7 @@ def add_associated_users(session, users, role=None):
 
             if fence_user:
                 if id and id != fence_user[0]["id"]:
-                    raise UserError(f"The user id {id} does not exist in the commons")
+                    raise UserError(f"The user id {id} does not match the email {email} in the commons")
                 else:
                     id = fence_user[0]["id"]
             

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,6 @@ def find_fence_user(fence_users):
             else:
                 if user['name'] in queryBody['usernames']:
                     return_users['users'].append(user)
-        print(return_users)
         return return_users
     yield get_fence_user
 
@@ -840,6 +839,117 @@ def filter_set_snapshot_get(session, client):
         return response
 
     yield route_filter_set_snapshot_get
+
+@pytest.fixture(scope="function", autouse=True)
+def admin_associated_user_post(session, client, mock_requests_post, find_fence_user):
+
+    def route_admin_associated_user_post(authorization_token, 
+                             users=None,
+                             role=None,
+                             status_code=200
+                             ):
+        
+        mock_requests_post()
+
+        json = {}
+        if users is not None:
+            json["users"] = users
+        if role is not None:
+            json["role"] = role
+
+        url = "/admin/associated_user"
+
+        response = client.post(url, json=json, headers={"Authorization": f'bearer {authorization_token}'})
+
+        assert response.status_code == status_code
+
+        if status_code == 200:
+            for user in users:
+                if "email" in user:
+                    associated_user = session.query(AssociatedUser).filter(AssociatedUser.email == user["email"]).first()
+                    project_user = session.query(ProjectAssociatedUser).filter(
+                        ProjectAssociatedUser.associated_user_id == associated_user.id and
+                        ProjectAssociatedUser.project_id == user["project_id"]
+                    ).first()
+                    fence_user = find_fence_user({"usernames":user["email"]})["users"]
+                else:
+                    associated_user = session.query(AssociatedUser).filter(AssociatedUser.user_id == user["id"]).first()
+                    project_user = session.query(ProjectAssociatedUser).filter(
+                        ProjectAssociatedUser.associated_user_id == associated_user.id and
+                        ProjectAssociatedUser.project_id == user["project_id"]
+                    ).first()
+                    fence_user = find_fence_user({"ids":[user["id"]]})["users"]
+                
+                if "id" in user:
+                    assert associated_user.user_id == user["id"]
+                
+                if "email" in user:
+                    assert associated_user.email == user["email"]
+                
+                if fence_user:
+                    assert associated_user.user_id == fence_user[0]["id"]
+                    assert associated_user.email == fence_user[0]["name"]
+
+                assert associated_user.user_source == "fence"
+                assert associated_user.active == True
+
+                assert project_user.project_id == user["project_id"]
+                assert project_user.associated_user_id == associated_user.id
+                assert project_user.role.code == role if role else config["ASSOCIATED_USER_ROLE_DEFAULT"]
+                assert project_user.active == True
+        
+        return response
+
+
+    yield route_admin_associated_user_post
+
+
+@pytest.fixture(scope="function", autouse=True)
+def admin_remove_associated_user_from_project_delete(session, client, mock_requests_post):
+
+    def route_admin_remove_associated_user_from_project_delete(authorization_token, 
+                             project_id=None,
+                             user_id=None,
+                             email=None,
+                             status_code=200
+                             ):
+        mock_requests_post()
+        url = f"/admin/remove_associated_user_from_project"
+
+        json = {}
+        if project_id is not None:
+            json["project_id"] = project_id
+        if user_id is not None:
+            json["user_id"] = user_id
+        if email is not None:
+            json["email"] = email
+
+        response = client.delete(url, json=json, headers={"Authorization": f'bearer {authorization_token}'})
+
+        assert response.status_code == status_code
+
+        if status_code == 200:
+            # Use join to query both tables
+            query = session.query(ProjectAssociatedUser).join(
+                AssociatedUser, 
+                ProjectAssociatedUser.associated_user_id == AssociatedUser.id
+            ).filter(
+                ProjectAssociatedUser.project_id == project_id
+            )
+            
+            if email:
+                query = query.filter(AssociatedUser.email == email)
+            elif user_id:
+                query = query.filter(AssociatedUser.user_id == user_id)
+                
+            project_user = query.first()
+            
+            assert project_user.active == False
+
+
+        return response
+
+    yield route_admin_remove_associated_user_from_project_delete
 
 
 # Add a finalizer to ensure proper teardown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1056,6 +1056,7 @@ def admin_copy_search_to_project(session, client, mock_requests_post):
         return response
     
     yield route_admin_copy_search_to_project
+
 @pytest.fixture(scope="function", autouse=True)
 def admin_associated_user_post(session, client, mock_requests_post, find_fence_user):
 

--- a/tests/test_blueprint_admin.py
+++ b/tests/test_blueprint_admin.py
@@ -140,3 +140,535 @@ def test_copy_search_to_user_search_doesnt_exist(register_user, login, filter_se
         user_id=user_id_2,
         status_code=404
     )
+
+
+def test_add_user_to_project(register_user, login, filter_set_post, project_post, admin_user, admin_associated_user_post):
+
+    user_id, user_email = register_user(email=f"user1@test_add_user_to_project.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_add_user_to_project", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_add_user_to_project",
+        institution="test_add_user_to_project",
+        associated_users_emails=[],
+        name="test_add_user_to_project", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    #with email in fence
+    user_2_id, user_2_email = register_user(email=f"user_2@test_add_user_to_project.com", name="user_2")
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"email":user_2_email, "project_id":project_id}]
+    )
+
+    #with email not in fence
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"email":"user_3@test_add_user_to_project.com", "project_id":project_id}]
+    )
+
+    #with id in fence
+    user_4_id, user_4_email = register_user(email=f"user_4@test_add_user_to_project.com", name="user_4")
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"id":user_4_id, "project_id":project_id}]
+    )
+
+    #with id and email in fence
+    user_5_id, user_5_email = register_user(email=f"user_5@test_add_user_to_project.com", name="user_5")
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"id":user_5_id, "email":user_5_email, "project_id":project_id}]
+    )
+
+    #with role
+    user_6_id, user_6_email = register_user(email=f"user_6@test_add_user_to_project.com", name="user_6")
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        role="DATA_ACCESS",
+        users=[{"id":user_6_id, "email":user_6_email, "project_id":project_id}]
+    )
+
+    #readd user
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"id":user_6_id, "email":user_6_email, "project_id":project_id}]
+    )
+
+
+def test_add_user_to_project_fail_missing_inputs(register_user, login, filter_set_post, project_post, admin_user, admin_associated_user_post):
+    user_id, user_email = register_user(email=f"user1@test_add_user_to_project_fail_missing_inputs.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_add_user_to_project_fail_missing_inputs", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_add_user_to_project_fail_missing_inputs",
+        institution="test_add_user_to_project_fail_missing_inputs",
+        associated_users_emails=[],
+        name="test_add_user_to_project_fail_missing_inputs", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"email":"user_2@test_add_user_to_project_fail_missing_inputs.com"}],
+        status_code=400
+    )
+
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"id":user_id}],
+        status_code=400
+    )
+
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"project_id":project_id}],
+        status_code=400
+    )
+
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{}],
+        status_code=400
+    )
+
+def test_add_user_to_project_fail_project_not_found(register_user, login, filter_set_post, project_post, admin_user, admin_associated_user_post):
+    user_id, user_email = register_user(email=f"user1@test_add_user_to_project_fail_project_not_found.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_add_user_to_project_fail_project_not_found", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_add_user_to_project_fail_project_not_found",
+        institution="test_add_user_to_project_fail_project_not_found",
+        associated_users_emails=[],
+        name="test_add_user_to_project_fail_project_not_found", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"email":"user_2@test_add_user_to_project_fail_project_not_found.com", "project_id":999999}],
+        status_code=404
+    )
+
+def test_add_user_to_project_fail_user_information_doesnt_match(register_user, login, filter_set_post, project_post, admin_user, admin_associated_user_post):
+    user_id, user_email = register_user(email=f"user1@test_add_user_to_project_fail_user_information_doesnt_match.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_add_user_to_project_fail_user_information_doesnt_match", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_add_user_to_project_fail_user_information_doesnt_match",
+        institution="test_add_user_to_project_fail_user_information_doesnt_match",
+        associated_users_emails=[],
+        name="test_add_user_to_project_fail_user_information_doesnt_match", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+
+    
+    
+
+
+    #email does not exist in fence and id is present
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"email":"user_2@test_add_user_to_project_fail_user_information_doesnt_match.com", "id":user_id, "project_id":project_id}],
+        status_code=400
+    )
+
+    #email exists in fence but id doesnt match email
+    user_id_2, user_email_2 = register_user(email=f"user_2@test_add_user_to_project_fail_user_information_doesnt_match.com", name="user_2")
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"email":user_email_2, "id":user_id, "project_id":project_id}],
+        status_code=400
+    )
+
+
+def test_add_user_to_project_fail_user_id_doesnt_exist(register_user, login, filter_set_post, project_post, admin_user, admin_associated_user_post):
+    user_id, user_email = register_user(email=f"user1@test_add_user_to_project_fail_user_id_doesnt_exist.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_add_user_to_project_fail_user_id_doesnt_exist", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_add_user_to_project_fail_user_id_doesnt_exist",
+        institution="test_add_user_to_project_fail_user_id_doesnt_exist",
+        associated_users_emails=[],
+        name="test_add_user_to_project_fail_user_id_doesnt_exist", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_associated_user_post(
+        authorization_token=admin_id,
+        users=[{"id":999999, "project_id":project_id}],
+        status_code=400
+    )
+
+def test_add_user_to_project_fail_missing_auth(register_user, login, filter_set_post, project_post, admin_user, admin_associated_user_post):
+    user_id, user_email = register_user(email=f"user1@test_add_user_to_project_fail_missing_auth.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_add_user_to_project_fail_missing_auth", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_add_user_to_project_fail_missing_auth",
+        institution="test_add_user_to_project_fail_missing_auth",
+        associated_users_emails=[],
+        name="test_add_user_to_project_fail_missing_auth", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+    assert admin_associated_user_post(
+        authorization_token=user_id,
+        users=[{"email":"user_2@test_add_user_to_project_fail_missing_auth.com", "project_id":project_id}],
+        status_code=403
+    )
+
+def test_remove_associated_user_from_project_success(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_success.com", name="user1")
+    user_3_id, user_3_email = register_user(email=f"user_3@test_remove_associated_user_from_project_success.com", name="user_3")
+    user_6_id, user_6_email = register_user(email=f"user_6@test_remove_associated_user_from_project_success.com", name="user_6")
+    user_7_id, user_7_email = register_user(email=f"user_7@test_remove_associated_user_from_project_success.com", name="user_7")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id, 
+        name="test_remove_associated_user_from_project_success", 
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id, 
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_success",
+        institution="test_remove_associated_user_from_project_success",
+        associated_users_emails=["user_2@test_remove_associated_user_from_project_success.com", 
+                                 "user_3@test_remove_associated_user_from_project_success.com", 
+                                 "user_4@test_remove_associated_user_from_project_success.com", 
+                                 "user_5@test_remove_associated_user_from_project_success.com", 
+                                 "user_6@test_remove_associated_user_from_project_success.com",
+                                 "user_7@test_remove_associated_user_from_project_success.com"],
+        name="test_remove_associated_user_from_project_success", 
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+
+    #what happens when user is added to project before signing up
+    #then user signs up but never goes to the data request page so their user_id doesnt get updated in table
+    #then user is removed from project using their user_id
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_success.com", name="user_2")
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_2_id
+    )
+
+    #same thing as above but both user_id and email
+    user_5_id, user_5_email = register_user(email=f"user_5@test_remove_associated_user_from_project_success.com", name="user_5")
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_5_id,
+        email=user_5_email
+    )
+
+    #user who is in fence before being added to project
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_3_id
+    )
+
+    #user who is in fence after being added to project delete with email
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        email="user_6@test_remove_associated_user_from_project_success.com"
+    )
+
+    #user who is in fence delete with both user_id and email
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_7_id,
+        email="user_7@test_remove_associated_user_from_project_success.com"
+    )
+
+    #user who is not in fence
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        email="user_4@test_remove_associated_user_from_project_success.com"
+    )
+
+def test_remove_associated_user_from_project_fail_missing_auth(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_fail_missing_auth.com", name="user1")
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_fail_missing_auth.com", name="user_2")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_remove_associated_user_from_project_fail_missing_auth",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_fail_missing_auth",
+        institution="test_remove_associated_user_from_project_fail_missing_auth",
+        associated_users_emails=[user_2_email],
+        name="test_remove_associated_user_from_project_fail_missing_auth",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=user_id,
+        project_id=project_id,
+        user_id=user_2_id,
+        status_code=403
+    )
+
+def test_remove_associated_user_from_project_fail_missing_inputs(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_fail_missing_inputs.com", name="user1")
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_fail_missing_inputs.com", name="user_2")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_remove_associated_user_from_project_fail_missing_inputs",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_fail_missing_inputs",
+        institution="test_remove_associated_user_from_project_fail_missing_inputs",
+        associated_users_emails=[user_2_email],
+        name="test_remove_associated_user_from_project_fail_missing_inputs",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+    
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        status_code=400
+    )
+
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        user_id=user_2_id,
+        status_code=400
+    )
+
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        email=user_2_email,
+        status_code=400
+    )
+
+
+def test_remove_associated_user_from_project_fail_user_not_found(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_fail_user_not_found.com", name="user1")
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_fail_user_not_found.com", name="user_2")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_remove_associated_user_from_project_fail_user_not_found",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_fail_user_not_found",
+        institution="test_remove_associated_user_from_project_fail_user_not_found",
+        associated_users_emails=[user_2_email],
+        name="test_remove_associated_user_from_project_fail_user_not_found",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=999999,
+        status_code=404
+    )
+
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        email="user_3@test_remove_associated_user_from_project_fail_user_not_found.com",
+        status_code=404
+    )
+
+def test_remove_associated_user_from_project_fail_user_not_associated_with_project(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_fail_user_not_associated_with_project.com", name="user1")
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_fail_user_not_associated_with_project.com", name="user_2")
+    user_3_id, user_3_email = register_user(email=f"user_3@test_remove_associated_user_from_project_fail_user_not_associated_with_project.com", name="user_3")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_remove_associated_user_from_project_fail_user_not_associated_with_project",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_fail_user_not_associated_with_project",
+        institution="test_remove_associated_user_from_project_fail_user_not_associated_with_project",
+        associated_users_emails=[user_2_email],
+        name="test_remove_associated_user_from_project_fail_user_not_associated_with_project",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    #person has already been removed
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        email=user_2_email,
+        status_code=200
+    )
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_2_id,
+        status_code=404
+    )
+    #person was never associated with project
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_3_id,
+        status_code=404
+    )
+
+def test_remove_associated_user_from_project_fail_project_not_found(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_fail_project_not_found.com", name="user1")
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_fail_project_not_found.com", name="user_2")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_remove_associated_user_from_project_fail_project_not_found",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_fail_project_not_found",
+        institution="test_remove_associated_user_from_project_fail_project_not_found",
+        associated_users_emails=[user_2_email],
+        name="test_remove_associated_user_from_project_fail_project_not_found",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=999999,
+        user_id=user_2_id,
+        status_code=404
+    )
+
+def test_remove_associated_user_from_project_fail_attempt_to_remove_owner(register_user, login, filter_set_post, project_post, admin_user, admin_remove_associated_user_from_project_delete):
+    user_id, user_email = register_user(email=f"user1@test_remove_associated_user_from_project_fail_attempt_to_remove_owner.com", name="user1")
+    user_2_id, user_2_email = register_user(email=f"user_2@test_remove_associated_user_from_project_fail_attempt_to_remove_owner.com", name="user_2")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_remove_associated_user_from_project_fail_attempt_to_remove_owner",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_remove_associated_user_from_project_fail_attempt_to_remove_owner",
+        institution="test_remove_associated_user_from_project_fail_attempt_to_remove_owner",
+        associated_users_emails=[user_2_email],
+        name="test_remove_associated_user_from_project_fail_attempt_to_remove_owner",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    admin_id, admin_email = admin_user
+    login(admin_id, admin_email)
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_id,
+        status_code=400
+    )
+
+    #attempt with email
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        email=user_email,
+        status_code=400
+    )
+
+    #attempt with both
+    assert admin_remove_associated_user_from_project_delete(
+        authorization_token=admin_id,
+        project_id=project_id,
+        user_id=user_id,
+        email=user_email,
+        status_code=400
+    )


### PR DESCRIPTION
for add associated user 
1) handles bug if project_id doenst exist
2) if email and user_id are passed and email doesnt exist in fence then user_id and email dont match so a UserError should be raised
also changes some variable names to make it easier to follow along with

for remove associated user
1) blocks removing project owner if email is used to remove someone
2) covers a small corner condition when someone is added to project before they sign up for portal then they sign in but never go to the data request page so they have a user_id but it doesn't exist in the amanuensis db and then an admin attempts to remove that person with their user_id, before it would throw a bug but now it sends a request to fence to get the email then updates the amanuensis DB and continues as normal

also adds session.commit to project get