### PR TITLE
Added new 'amanuensis/all_notifications' API endpoint that retrieves all notifications

### DIFF
--- a/amanuensis/__init__.py
+++ b/amanuensis/__init__.py
@@ -73,6 +73,7 @@ def app_register_blueprints(app):
     app.register_blueprint(amanuensis.blueprints.filterset.blueprint, url_prefix="/filter-sets")
     app.register_blueprint(amanuensis.blueprints.project.blueprint, url_prefix="/projects")
     app.register_blueprint(amanuensis.blueprints.notification.blueprint, url_prefix="/notifications")
+    app.register_blueprint(amanuensis.blueprints.notification.blueprint_all, url_prefix="/all-notifications")
     # Disable for now since they are not used yet
     # app.register_blueprint(amanuensis.blueprints.message.blueprint, url_prefix="/message")
     

--- a/amanuensis/blueprints/notification.py
+++ b/amanuensis/blueprints/notification.py
@@ -3,7 +3,7 @@ import flask
 from amanuensis.auth.auth import current_user
 from amanuensis.errors import AuthError
 from amanuensis.schema import NotificationSchema
-from amanuensis.resources.notification import update_users_notifications
+from amanuensis.resources.notification import update_users_notifications, get_all_notifications
 from cdislogging import get_logger
 
 logger = get_logger(__name__)
@@ -30,5 +30,20 @@ def retrieve_notifications():
         return notification_schema.dump(messages)
 
 
+blueprint_all = flask.Blueprint("all_notifications", __name__)
 
+@blueprint_all.route("/", methods=["GET"])
+def retrive_all_notifications():
+    try:
+        logged_user_id = current_user.id
+    except AuthError:
+        logger.warning(
+            "Unable to load or find the user, check your token"
+        )
+        return flask.jsonify({"error": "Unauthorized"}), 401 
+    with flask.current_app.db.session as session:
+        notification_schema = NotificationSchema(many=True)
+        messages = get_all_notifications(session, logged_user_id)
+        session.commit()
+        return notification_schema.dump(messages)
 

--- a/amanuensis/resources/notification/__init__.py
+++ b/amanuensis/resources/notification/__init__.py
@@ -22,3 +22,9 @@ def update_users_notifications(session, user_id):
     
 
     return latest_notifications
+
+def get_all_notifications(session, user_id):
+    all_notifs = get_notification_logs(session, expired = False) 
+    for notification in all_notifs: 
+        create_notification(session, notification_log_id=notification.id, user_id=user_id)
+    return all_notifs


### PR DESCRIPTION
For work on the new message center. 

Currently, calling GET `amanuensis/notifications` only returns unread notifications. This new API endpoint retrieves all notifications (including read ones), so that they can be displayed in Profile -> Message Center.