### PR TITLE
Improve disease_phase filter handling and add tests

### DIFF
--- a/migrations/versions/fca96219902c_update_filters_from_old_version.py
+++ b/migrations/versions/fca96219902c_update_filters_from_old_version.py
@@ -52,7 +52,7 @@ def upgrade() -> None:
     def proccess_filter_object(filter_object):
         selected_filters = {}  
         for key, value in filter_object.items():
-            if "disease_phase" in key:
+            if "disease_phase:Initial Diagnosis" in key or "disease_phase:Relapse" in key:
                 # Handle disease_phase filters with anchor type
                 selected_filters[key] = anchor_filter_setter(value)
             elif "selectedValues" in value:

--- a/tests/test_update_filters_from_old_version.py
+++ b/tests/test_update_filters_from_old_version.py
@@ -35,7 +35,10 @@ def test_update_filters_from_old_version(session):
 
     #anchored combined mode present with and
     search_5 = Search(name="test_update_filters_from_old_version-old_version_anchor_filter_combined_mode_present",
-           filter_object={"sex": {"selectedValues": ["Male"]}, "race": {"selectedValues": ["Asian"]}, "__combineMode": "AND", "disease_phase:Initial Diagnosis": {"filter": {"tumor_assessments.tumor_classification": {"selectedValues": ["Primary"]}}}})       
+           filter_object={"sex": {"selectedValues": ["Male"]}, "race": {"selectedValues": ["Asian"]}, "__combineMode": "AND", 
+                          "disease_phase:Initial Diagnosis": {"filter": {"tumor_assessments.tumor_classification": {"selectedValues": ["Primary"]}}},
+                          "disease_phase:Relapse": {"filter": {"tumor_assessments.tumor_classification": {"selectedValues": ["Metastatic"]}}}
+                          })       
     
     search_6 = Search(name="test_update_filters_from_old_version-normal_filter_set",
                       filter_object={"value": {"sex": {"__type": "OPTION", "selectedValues": ["Male"]}, "consortium": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["INTERACT"]}}, "__type": "STANDARD", "__combineMode": "AND"}
@@ -45,8 +48,14 @@ def test_update_filters_from_old_version(session):
     search_7 = Search(name=f"test_update_filters_from_old_version-old_version_two_options",
            filter_object={"sex": {"selectedValues": ["Female"]}, "consortium": {"selectedValuess": ["INSTRuCT"]}}
     )
-    
-    session.add_all([search_1, search_2, search_3, search_4, search_5, search_6, search_7])
+
+    #test year_at_disease_phase
+    search_8 = Search(name=f"test_update_filters_from_old_version-old_version_year_at_disease_phase",
+                      filter_object={"sex": {"selectedValues": ["Female"]}, "consortium": {"selectedValues": ["INSTRuCT"]}, "__combineMode": "AND", "year_at_disease_phase": {"lowerBound": 2010, "upperBound": 2016}}
+    )
+                      
+
+    session.add_all([search_1, search_2, search_3, search_4, search_5, search_6, search_7, search_8])
     session.commit()
 
     alembic_main(["--raiseerr", "upgrade", "head"])
@@ -58,11 +67,16 @@ def test_update_filters_from_old_version(session):
     session.refresh(search_5)
     session.refresh(search_6)
     session.refresh(search_7)
+    session.refresh(search_8)
 
     assert search_1.filter_object == {}
     assert search_2.filter_object == {"__combineMode": "AND", "__type": 'STANDARD', "value": {"sex": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Female"]}, "consortium": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["INSTRuCT"]}}}
     assert search_3.filter_object == {"__combineMode": "AND", "__type": 'STANDARD', "value": {"sex": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Male", "Female"]}}}
     assert search_4.filter_object == {"__combineMode": "OR", "__type": 'STANDARD', "value": {"sex": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Male"]}, "age_at_censor_status": {"__type": "RANGE", "lowerBound": 6479, "upperBound": 10268}}}
-    assert search_5.filter_object == {"__combineMode": "AND", "__type": 'STANDARD', "value": {"sex": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Male"]}, "race": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Asian"]}, "disease_phase:Initial Diagnosis": {"__type": "ANCHOR", "value": {"tumor_assessments.tumor_classification": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Primary"]}}}}}
+    assert search_5.filter_object == {"__combineMode": "AND", "__type": 'STANDARD', "value": {"sex": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Male"]}, "race": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Asian"]}, 
+                                                                                              "disease_phase:Initial Diagnosis": {"__type": "ANCHOR", "value": {"tumor_assessments.tumor_classification": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Primary"]}}},
+                                                                                              "disease_phase:Relapse": {"__type": "ANCHOR", "value": {"tumor_assessments.tumor_classification": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Metastatic"]}}}
+                                                                                              }}
     assert search_6.filter_object == {"value": {"sex": {"__type": "OPTION", "selectedValues": ["Male"]}, "consortium": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["INTERACT"]}}, "__type": "STANDARD", "__combineMode": "AND"}
     assert search_7.filter_object == {"sex": {"selectedValues": ["Female"]}, "consortium": {"selectedValuess": ["INSTRuCT"]}}
+    assert search_8.filter_object == {"__combineMode": "AND", "__type": 'STANDARD', "value": {"sex": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["Female"]}, "consortium": {"__type": "OPTION", "isExclusion": False, "selectedValues": ["INSTRuCT"]}, "year_at_disease_phase": {"__type": "RANGE", "lowerBound": 2010, "upperBound": 2016}}}


### PR DESCRIPTION
Updated the migration logic to specifically check for 'disease_phase:Initial Diagnosis' and 'disease_phase:Relapse' keys. Enhanced test coverage by adding cases for multiple disease_phase filters and year_at_disease_phase range filters.