### PR TITLE
Add admin endpoints and tests for project approved_url

### DIFF
--- a/amanuensis/blueprints/project.py
+++ b/amanuensis/blueprints/project.py
@@ -105,7 +105,8 @@ def get_projetcs():
             tmp_project["status"] = get_states(session, code=project_status["status"], many=False, filter_out_depricated=True).name if project_status["status"] else "ERROR"
             tmp_project["submitted_at"] = submitted_at
             tmp_project["completed_at"] = project_status["completed_at"] if "completed_at" in project_status else None
-
+            tmp_project["description"] = project.description
+            tmp_project["approved_url_present"] = True if project.approved_url else False
             tmp_project["has_access"] = False
             for user in project.associated_users_roles:
                 if user.role and user.role.code == "DATA_ACCESS" and user.active and (user.associated_user.user_id == logged_user_id or user.associated_user.email == logged_user_email):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1343,6 +1343,73 @@ def download_urls_get(session, client):
     yield route_download_urls_post
 
 
+@pytest.fixture(scope="session", autouse=True)
+def admin_update_project_put(session, client):
+    def route_admin_update_project_put(authorization_token, 
+                             project_id=None,
+                             approved_url=None,
+                             status_code=200
+                             ):
+        
+        json = {}
+        if approved_url is not None:
+            json["approved_url"] = approved_url
+        if project_id is not None:
+            json["project_id"] = project_id
+
+        url = "admin/projects"
+
+        response = client.put(url, json=json, headers={"Authorization": f'bearer {authorization_token}'})
+
+        assert response.status_code == status_code
+        
+        if status_code == 200:
+
+            project = session.query(Project).filter(Project.id == project_id).first()
+
+            assert project.approved_url == approved_url
+        
+        elif status_code == 404:
+
+            project = session.query(Project).filter(Project.id == project_id).first()
+
+            assert project is None
+        
+        return response
+    
+    yield route_admin_update_project_put
+
+
+@pytest.fixture(scope="session", autouse=True)
+def admin_get_approved_url_get(session, client):
+    def route_admin_get_approved_url_get(authorization_token, 
+                             project_id=None,
+                             status_code=200
+                             ):
+
+        url = "/admin/project/approved-url/" + (str(project_id) if project_id is not None else "")
+
+        response = client.get(url, headers={"Authorization": f'bearer {authorization_token}'})
+
+        assert response.status_code == status_code
+        
+        if status_code == 200:
+
+            project = session.query(Project).filter(Project.id == project_id).first()
+
+            assert project.approved_url == response.json["approved_url"]
+
+        if status_code == 404:
+
+            project = session.query(Project).filter(Project.id == project_id).first()
+
+            assert project is None or project.approved_url is None
+        
+        return response
+
+    yield route_admin_get_approved_url_get
+
+
 # Add a finalizer to ensure proper teardown
 @pytest.fixture(scope="session", autouse=True)
 def teardown(request, app_instance, session):

--- a/tests/test_blueprint_admin.py
+++ b/tests/test_blueprint_admin.py
@@ -1409,3 +1409,193 @@ def test_download_url_with_new_aws_version(register_user, session, login, filter
         project_id=project_id,
         status_code=200
     )
+
+
+def test_admin_update_project_put_success(register_user, login, filter_set_post, project_post, admin_user, admin_update_project_put):
+    user_id, user_email = register_user(email=f"user1@test_change_project_approved_url_success.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_change_project_approved_url_success",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_change_project_approved_url_success",
+        institution="test_change_project_approved_url_success",
+        associated_users_emails=[],
+        name="test_change_project_approved_url_success",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_update_project_put(
+        authorization_token=admin_user[0],
+        project_id=project_id,
+        approved_url="https://amanuensis-bucket.s3.amazonaws.com/test.json",
+        status_code=200
+    )
+
+def test_admin_update_project_put_fail_user_not_admin(register_user, login, filter_set_post, project_post, admin_user, admin_update_project_put):
+    user_id, user_email = register_user(email=f"user1@test_admin_update_project_put_fail_user_not_admin.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_admin_update_project_put_fail_user_not_admin",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_admin_update_project_put_fail_user_not_admin",
+        institution="test_admin_update_project_put_fail_user_not_admin",
+        associated_users_emails=[],
+        name="test_admin_update_project_put_fail_user_not_admin",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_update_project_put(
+        authorization_token=user_id,
+        project_id=project_id,
+        approved_url="https://amanuensis-bucket.s3.amazonaws.com/test.json",
+        status_code=403
+    )
+
+def test_admin_update_project_put_fail_missing_parameters(register_user, login, filter_set_post, project_post, admin_user, admin_update_project_put):
+    user_id, user_email = register_user(email=f"user1@test_admin_update_project_put_fail_missing_parameters.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_admin_update_project_put_fail_missing_parameters",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_admin_update_project_put_fail_missing_parameters",
+        institution="test_admin_update_project_put_fail_missing_parameters",
+        associated_users_emails=[],
+        name="test_admin_update_project_put_fail_missing_parameters",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_update_project_put(
+        authorization_token=admin_user[0],
+        approved_url="https://amanuensis-bucket.s3.amazonaws.com/test.json",
+        status_code=400
+    )
+
+    assert admin_update_project_put(
+        authorization_token=admin_user[0],
+        project_id=project_id,
+        status_code=400
+    )
+
+    assert admin_update_project_put(
+        authorization_token=admin_user[0],
+        project_id=999999,
+        approved_url="https://amanuensis-bucket.s3.amazonaws.com/test.json",
+        status_code=404
+    )
+
+def test_get_approved_url_success(register_user, login, filter_set_post, project_post, admin_user, admin_update_project_put, admin_get_approved_url_get):
+    user_id, user_email = register_user(email=f"user1@test_get_approved_url_success.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_get_approved_url_success",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_get_approved_url_success",
+        institution="test_get_approved_url_success",
+        associated_users_emails=[],
+        name="test_get_approved_url_success",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_update_project_put(
+        authorization_token=admin_user[0],
+        project_id=project_id,
+        approved_url="https://amanuensis-bucket.s3.amazonaws.com/test.json",
+        status_code=200
+    )
+
+    assert admin_get_approved_url_get(
+        authorization_token=admin_user[0],
+        project_id=project_id,
+        status_code=200
+    )
+
+def test_get_approved_url_fail_user_not_admin(register_user, login, filter_set_post, project_post, admin_user, admin_get_approved_url_get):
+    user_id, user_email = register_user(email=f"user1@test_get_approved_url_fail_user_not_admin.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_get_approved_url_fail_user_not_admin",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_get_approved_url_fail_user_not_admin",
+        institution="test_get_approved_url_fail_user_not_admin",
+        associated_users_emails=[],
+        name="test_get_approved_url_fail_user_not_admin",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_get_approved_url_get(
+        authorization_token=user_id,
+        project_id=project_id,
+        status_code=403
+    )
+
+def test_get_approved_url_fail_missing_parameters(register_user, login, filter_set_post, project_post, admin_user, admin_update_project_put, admin_get_approved_url_get):
+    user_id, user_email = register_user(email=f"user1@test_get_approved_url_fail_missing_parameters.com", name="user1")
+    login(user_id, user_email)
+    filter_set_id = filter_set_post(
+        user_id,
+        name="test_get_approved_url_fail_missing_parameters",
+        filter_object={"consortium":{"__type":"OPTION","selectedValues":["INSTRUCT", "INRG"],"isExclusion":False}},
+        graphql_object={"AND":[{"IN":{"consortium":["INSTRUCT", "INRG"]}}]}
+    ).json["id"]
+    project_id = project_post(
+        authorization_token=user_id,
+        consortiums_to_be_returned_from_pcdc_analysis_tools=["INSTRUCT", "INRG"],
+        description="test_get_approved_url_fail_missing_parameters",
+        institution="test_get_approved_url_fail_missing_parameters",
+        associated_users_emails=[],
+        name="test_get_approved_url_fail_missing_parameters",
+        filter_set_ids=[filter_set_id]
+    ).json["id"]
+
+    assert admin_get_approved_url_get(
+        authorization_token=admin_user[0],
+        status_code=404
+    )
+
+    assert admin_update_project_put(
+        authorization_token=admin_user[0],
+        project_id=project_id,
+        approved_url="https://amanuensis-bucket.s3.amazonaws.com/test.json",
+        status_code=200
+    )
+
+    assert admin_get_approved_url_get(
+        authorization_token=admin_user[0],
+        status_code=404
+    )
+
+    assert admin_get_approved_url_get(
+        authorization_token=admin_user[0],
+        project_id=999999,
+        status_code=404
+    )


### PR DESCRIPTION
Introduces a required 'approved_url' field in the admin project update endpoint and adds a new admin endpoint to retrieve a project's approved_url. Updates project listing to include description and approved_url presence. Adds comprehensive tests and fixtures for these admin endpoints, including success and failure scenarios.