### PR TITLE
Add default S3 region to config

### DIFF
--- a/amanuensis/config-default.yaml
+++ b/amanuensis/config-default.yaml
@@ -156,6 +156,7 @@ AWS_CREDENTIALS:
     aws_secret_access_key: ""
   DATA_DELIVERY_S3_BUCKET:
     bucket_name: ""
+    region_name: "us-east-1"
     aws_access_key_id: ""
     aws_secret_access_key: ""
   


### PR DESCRIPTION
Add region_name: "us-east-1" to DATA_DELIVERY_S3_BUCKET in amanuensis/config-default.yaml. This provides a default AWS region for S3 operations so clients that rely on this config have a region set when accessing the delivery bucket; other AWS credential fields are unchanged.