### PR TITLE
Log exception when BotoManager init fails

### DIFF
--- a/amanuensis/__init__.py
+++ b/amanuensis/__init__.py
@@ -160,6 +160,7 @@ def _setup_data_endpoint_and_boto(app):
         app.s3_boto = BotoManager(aws_creds, logger=logger)
     except Exception as e:
         logger.error(f"Could not initialize data delivery BotoManager.")
+        logger.error(e)
         app.s3_boto = None
 
     try:


### PR DESCRIPTION
Add logger.error(e) in amanuensis.__init__::_setup_data_endpoint_and_boto to record the caught exception when initializing the data delivery BotoManager fails. This provides the underlying error details for easier debugging while retaining the original error message and fallback behavior (app.s3_boto = None).